### PR TITLE
Translate blog posts for language switcher

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -3,9 +3,12 @@ layout: default
 ---
 <article class="post">
   <header class="post-header">
-    <a href="{{ '/blog' | relative_url }}" class="back-to-posts">← Back to Posts</a>
-    <h1>{{ page.title }}</h1>
-    <p class="meta">{{ page.date | date_to_string }}</p>
+    <a href="{{ '/blog' | relative_url }}" class="back-to-posts" data-en="← Back to Posts" data-de="← Zurück zu den Beiträgen">← Back to Posts</a>
+    <h1>
+      <span data-lang="en">{{ page.title_en | default: page.title }}</span>
+      {% if page.title_de %}<span data-lang="de" hidden>{{ page.title_de }}</span>{% endif %}
+    </h1>
+    <p class="meta">{{ page.date | date: "%d.%m.%Y" }}</p>
   </header>
 
   <div class="post-content-wrapper">
@@ -20,12 +23,13 @@ layout: default
   {% endfor %}
   {% if podcast_file_exists %}
   <div class="podcast-player">
-    <h3>Listen to this post:</h3>
+    <h3 data-en="Listen to this post:" data-de="Diesen Beitrag anhören:">Listen to this post:</h3>
     <audio controls>
       <source src="{{ site.baseurl }}/{{ page.podcast_link }}" type="audio/mpeg">
-      Your browser does not support the audio element.
+      <p data-lang="en">Your browser does not support the audio element.</p>
+      <p data-lang="de" hidden>Ihr Browser unterstützt das Audioelement nicht.</p>
     </audio>
-    <a href="{{ site.baseurl }}/{{ page.podcast_link }}" download>Download podcast</a>
+    <a href="{{ site.baseurl }}/{{ page.podcast_link }}" download data-en="Download podcast" data-de="Podcast herunterladen">Download podcast</a>
   </div>
   {% endif %}
   {% endif %}

--- a/_posts/2025-01-13-welcome-to-my-blog.md
+++ b/_posts/2025-01-13-welcome-to-my-blog.md
@@ -4,10 +4,12 @@ date: 2025-01-13 21:55:21 +0100
 layout: post
 podcast_link: assets/podcasts/2025-01-13-welcome-to-my-blog.mp3
 title: Welcome to My Blog
+title_de: Willkommen in meinem Blog
+excerpt_en: "Hello and welcome to my blog! I'm excited to share my explorations of software development with you."
+excerpt_de: "Hallo und willkommen in meinem Blog! Ich freue mich darauf, meine Entdeckungen in der Softwareentwicklung mit dir zu teilen."
 ---
 
-
-
+<div data-lang="en" markdown="1">
 Hello and welcome to my blog! I'm excited to share my explorations of software development with you.
 
 In this blog, I'll be focusing on:
@@ -20,4 +22,21 @@ In this blog, I'll be focusing on:
 - Sharing insights and experiences from my journey
 - Discussing the potential and challenges of AI-assisted development
 
-Stay tuned for regular updates as I dive into this fascinating intersection of traditional software development and cutting-edge AI technologies. Feel free to reach out if you have any questions or topics you'd like me to explore! 
+Stay tuned for regular updates as I dive into this fascinating intersection of traditional software development and cutting-edge AI technologies. Feel free to reach out if you have any questions or topics you'd like me to explore!
+</div>
+
+<div data-lang="de" hidden markdown="1">
+Hallo und willkommen in meinem Blog! Ich freue mich darauf, meine Entdeckungen in der Softwareentwicklung mit dir zu teilen.
+
+In diesem Blog werde ich mich auf folgende Themen konzentrieren:
+- Die neuesten Trends in der KI-unterstützten Softwareentwicklung
+- Tipps und Tricks, wie du LLMs in deinen Arbeitsablauf integrieren kannst
+- Bewährte Methoden für die Zusammenarbeit mit KI-Agenten
+
+- Die Erkundung von Softwareentwicklung mit Hilfe großer Sprachmodelle (LLMs)
+- Den Einsatz von KI-Agenten im Entwicklungsprozess
+- Das Teilen von Erkenntnissen und Erfahrungen aus meinem Alltag
+- Die Chancen und Herausforderungen der KI-gestützten Entwicklung
+
+Bleib dran für regelmäßige Updates, während ich in diese faszinierende Schnittmenge aus klassischer Softwareentwicklung und modernsten KI-Technologien eintauche. Melde dich gern, wenn du Fragen hast oder ein Thema vorschlagen möchtest!
+</div>

--- a/_posts/2025-09-21-introducing-my-ai-health-research-companion.md
+++ b/_posts/2025-09-21-introducing-my-ai-health-research-companion.md
@@ -1,10 +1,14 @@
 ---
 layout: post
 title: "Introducing My Health Research Companion"
+title_de: "Vorstellung meines Health Research Companion"
 date: 2025-09-21 10:00:00 +0100
 categories: health
+excerpt_en: "I've been building an AI-driven Health Research Companion to turn complex medical records into actionable insights for my family."
+excerpt_de: "Ich habe einen KI-gestützten Health Research Companion entwickelt, der komplexe medizinische Befunde in konkrete Erkenntnisse für meine Familie übersetzt."
 ---
 
+<div data-lang="en" markdown="1">
 In my free time I’ve been working on something that started from a very personal need as a parent. Over the years I’ve collected stacks of paper diagnoses (MR, CT scans, lab results), often written in complex language that’s difficult to interpret. I felt AI could be a perfect fit to make this easier.
 
 The main motivation came from my daughter’s journey with atopic dermatitis. After you receive a diagnosis with “no cure,” doctors usually stop searching for new treatments or dietary options. But I kept looking into medical journals myself, surfacing possible new therapies or lifestyle adjustments.
@@ -30,4 +34,33 @@ Here are some screenshots so you can get a better idea of how the AI Health Rese
 ![AI Health Research Companion Research Details](/assets/researchDetails.jpeg)
 
 ![AI Health Research Companion Podcast Dialog](/assets/podcastDialog.jpeg)
+</div>
+
+<div data-lang="de" hidden markdown="1">
+In meiner Freizeit habe ich an etwas gearbeitet, das aus einem sehr persönlichen Bedürfnis als Elternteil entstanden ist. Im Laufe der Jahre habe ich Stapel von Papierdiagnosen gesammelt (MRT-, CT-Scans, Laborergebnisse), oft in komplizierter Sprache, die schwer zu verstehen ist. Ich hatte das Gefühl, dass KI perfekt geeignet ist, um das zu vereinfachen.
+
+Die Hauptmotivation kam aus dem Weg meiner Tochter mit atopischer Dermatitis. Nachdem man eine Diagnose wie „keine Heilung“ erhält, hören Ärzt:innen meist auf, nach neuen Behandlungen oder Ernährungsoptionen zu suchen. Ich habe jedoch weiter selbst in medizinischen Fachzeitschriften recherchiert und mögliche neue Therapien oder Anpassungen im Lebensstil gefunden.
+
+Genau dabei setzt die App an: Sie hilft Nutzer:innen, vielversprechende Forschungsergebnisse und Optionen zu finden, die sie anschließend mit ihrer Ärztin oder ihrem Arzt besprechen können – die medizinische Fachperson entscheidet weiterhin, was im jeweiligen Fall sinnvoll ist.
+
+Außerdem, inspiriert davon, wie sehr ich NotebookLM schätze, habe ich Podcasts ergänzt: Hosts erklären die Diagnose in einfachen Worten, dazu kommt ein kurzer „Radionachrichten“-Abschnitt mit aktuellen Forschungsergebnissen.
+
+Die App ist über Firebase App Testing für Android verfügbar (noch nicht im Play Store), iOS folgt bald. Freund:innen, die sie testen, finden sie bereits hilfreich, und ich freue mich über weiteres Feedback – wenn du sie ausprobieren möchtest, melde dich gern!
+
+Bevor ich die App breiter veröffentliche, muss ich außerdem klären, welche Vorgaben für gesundheitsbezogene Apps in Bezug auf Play-Store-/App-Store-Richtlinien und nationale Regulierung gelten.
+
+## App-Screenshots
+
+Hier sind ein paar Screenshots, damit du dir besser vorstellen kannst, wie der AI Health Research Companion funktioniert:
+
+![AI Health Research Companion Home Screen](/assets/homeScreen.jpeg)
+
+![AI Health Research Companion Details Screen](/assets/detailsScreen.jpeg)
+
+![AI Health Research Companion Research Dialog](/assets/researchDialog.jpeg)
+
+![AI Health Research Companion Research Details](/assets/researchDetails.jpeg)
+
+![AI Health Research Companion Podcast Dialog](/assets/podcastDialog.jpeg)
+</div>
 

--- a/blog.html
+++ b/blog.html
@@ -3,18 +3,24 @@ layout: default
 title: Blog
 ---
 <div class="blog-list">
-    <h1>All Blog Posts</h1>
+    <h1 data-en="All Blog Posts" data-de="Alle Blogbeiträge">All Blog Posts</h1>
     {% for post in site.posts %}
     <article class="blog-post">
-        <h2><a href="{{ post.url | relative_url }}">{{ post.title }}</a></h2>
+        <h2>
+            <a href="{{ post.url | relative_url }}" data-en="{{ post.title | escape }}" data-de="{{ post.title_de | default: post.title | escape }}">{{ post.title }}</a>
+        </h2>
         <div class="blog-post-meta">
-            <time datetime="{{ post.date | date_to_xmlschema }}">{{ post.date | date: "%B %-d, %Y" }}</time>
+            <time datetime="{{ post.date | date_to_xmlschema }}">{{ post.date | date: "%d.%m.%Y" }}</time>
             {% if post.categories %}
-                <span> | Categories: {{ post.categories | join: ", " }}</span>
+                <span data-lang="en"> | Categories: {{ post.categories | join: ", " }}</span>
+                <span data-lang="de" hidden> | Kategorien: {{ post.categories | join: ", " }}</span>
             {% endif %}
         </div>
-        <p>{{ post.excerpt | strip_html | truncatewords: 50 }}</p>
-        <a href="{{ post.url | relative_url }}" class="read-more">Read more</a>
+        <p data-lang="en">{{ post.excerpt_en | default: post.excerpt | strip_html | truncatewords: 50 }}</p>
+        {% if post.excerpt_de %}
+        <p data-lang="de" hidden>{{ post.excerpt_de }}</p>
+        {% endif %}
+        <a href="{{ post.url | relative_url }}" class="read-more" data-en="Read more" data-de="Weiterlesen">Read more</a>
     </article>
     {% endfor %}
-</div> 
+</div>

--- a/blog/index.html
+++ b/blog/index.html
@@ -4,15 +4,24 @@ title: Blog
 ---
 
 <div class="blog-list">
-    <h1>Latest Blog Posts</h1>
-
-    <ul>
-      {% for post in site.posts %}
-        <li>
-          <h2><a href="{{ post.url | relative_url }}">{{ post.title }}</a></h2>
-          <p>{{ post.date | date_to_string }}</p>
-          <p>{{ post.excerpt }}</p>
-        </li>
-      {% endfor %}
-    </ul> 
+    <h1 data-en="All Blog Posts" data-de="Alle Blogbeiträge">All Blog Posts</h1>
+    {% for post in site.posts %}
+    <article class="blog-post">
+        <h2>
+            <a href="{{ post.url | relative_url }}" data-en="{{ post.title | escape }}" data-de="{{ post.title_de | default: post.title | escape }}">{{ post.title }}</a>
+        </h2>
+        <div class="blog-post-meta">
+            <time datetime="{{ post.date | date_to_xmlschema }}">{{ post.date | date: "%d.%m.%Y" }}</time>
+            {% if post.categories %}
+                <span data-lang="en"> | Categories: {{ post.categories | join: ", " }}</span>
+                <span data-lang="de" hidden> | Kategorien: {{ post.categories | join: ", " }}</span>
+            {% endif %}
+        </div>
+        <p data-lang="en">{{ post.excerpt_en | default: post.excerpt | strip_html | truncatewords: 50 }}</p>
+        {% if post.excerpt_de %}
+        <p data-lang="de" hidden>{{ post.excerpt_de }}</p>
+        {% endif %}
+        <a href="{{ post.url | relative_url }}" class="read-more" data-en="Read more" data-de="Weiterlesen">Read more</a>
+    </article>
+    {% endfor %}
 </div>

--- a/script.js
+++ b/script.js
@@ -103,11 +103,21 @@ function setLanguage(lang) {
     // Store selected language
     localStorage.setItem('language', lang);
 
+    // Update document language attributes
+    document.documentElement.setAttribute('lang', lang);
+    document.documentElement.setAttribute('data-language', lang);
+
     // Update text for all elements with a data-en or data-de attribute
     document.querySelectorAll('[data-en], [data-de]').forEach(el => {
         const translation = el.getAttribute(`data-${lang}`);
         if (translation) {
             el.textContent = translation;
         }
+    });
+
+    // Toggle visibility for language-specific elements
+    document.querySelectorAll('[data-lang]').forEach(el => {
+        const shouldShow = el.getAttribute('data-lang') === lang;
+        el.hidden = !shouldShow;
     });
 }


### PR DESCRIPTION
## Summary
- extend the language switcher to toggle dedicated language blocks alongside existing data attribute translations
- update the blog listings to surface English and German titles, metadata labels, and excerpts from each post
- add localized English and German bodies, titles, and excerpts for existing blog posts so content matches the selected flag

## Testing
- bundle exec jekyll build *(fails: `jekyll` executable not available in container)*
- bundle install *(fails: cannot download gems due to HTTP 403 from rubygems.org)*

------
https://chatgpt.com/codex/tasks/task_e_68cfff9a19a08333bc0b495fb92c83b0