### PR TITLE
Add AI mode toggle with markdown export (EN/DE)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@ source "https://rubygems.org"
 
 gem "github-pages", "~> 228", group: :jekyll_plugins
 gem "webrick", "~> 1.7"
+gem "csv"
 
 group :jekyll_plugins do
   gem "jekyll-feed", "~> 0.12"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -27,6 +27,7 @@ GEM
     commonmarker (0.23.11)
     concurrent-ruby (1.3.4)
     connection_pool (2.5.0)
+    csv (3.3.5)
     dnsruby (1.72.3)
       base64 (~> 0.2.0)
       simpleidn (~> 0.2.1)
@@ -298,6 +299,7 @@ PLATFORMS
   x86_64-linux-musl
 
 DEPENDENCIES
+  csv
   github-pages (~> 228)
   jekyll-feed (~> 0.12)
   tzinfo (>= 1, < 3)

--- a/index.html
+++ b/index.html
@@ -59,9 +59,78 @@ layout: none
                         <path d="M12.1 22c-0.3 0-0.6 0-0.9 0-5.5-0.5-9.5-5.4-9-10.9 0.4-4.8 4.2-8.6 9-9 0.4 0 0.8 0.2 1 0.5 0.2 0.3 0.2 0.8-0.1 1.1-2 2.7-1.4 6.4 1.3 8.4 2.1 1.6 5 1.6 7.1 0 0.3-0.2 0.7-0.3 1.1-0.1 0.3 0.2 0.5 0.6 0.5 1 -0.2 2.7-1.5 5.1-3.6 6.8C16.6 21.2 14.4 22 12.1 22zM9.3 4.4c-2.9 1-5 3.6-5.2 6.8-0.4 4.4 2.8 8.3 7.2 8.7 2.1 0.2 4.2-0.4 5.8-1.8 1.1-0.9 1.9-2.1 2.4-3.4-2.5 0.9-5.3 0.5-7.5-1.1C9.2 11.4 8.1 7.7 9.3 4.4z"/>
                     </svg>
                 </button>
+                <button id="ai-toggle" class="ai-toggle" aria-label="Toggle AI mode" aria-pressed="false">
+                    <svg class="icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+                        <path d="M6 2h8l4 4v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2zm7 1.5V7h3.5L13 3.5zM7.5 10.5h9v-1.5h-9v1.5zm0 3h9v-1.5h-9v1.5zm0 3h6v-1.5h-6v1.5z"/>
+                    </svg>
+                </button>
             </div>
         </div>
     </nav>
+
+    <section id="ai-mode" class="ai-mode-panel" aria-live="polite">
+        <div class="ai-mode-header">
+            <h1 data-en="AI Mode" data-de="KI-Modus">AI Mode</h1>
+            <button id="ai-copy" class="ai-copy" data-en="Copy Markdown" data-de="Markdown kopieren">Copy Markdown</button>
+        </div>
+        <pre class="ai-markdown"><code id="ai-markdown"></code></pre>
+    </section>
+
+    <template id="ai-markdown-en">
+# Luka Finžgar
+
+## Summary
+- Curious creature aiming to build systems that would make our everyday lives easier. With extensive experience in mobile development, I bring your mobile vision to life with clean code and stunning design.
+- Focus areas: iOS, Android
+
+## Featured Projects
+- **Toshl Finance** — Working on personal finance management app Toshl for iOS and Android since December 2018. Helping users manage their finances effectively through intuitive mobile interfaces.
+  - Technologies: iOS, Android, Mobile Development
+- **CarLock** — Co-founded and developed CarLock from January 2013 to November 2015. Created Android and iOS apps that displayed driving style and other data from a device in the car, enhancing vehicle security and driver awareness.
+  - Technologies: iOS, Android, IoT
+- **KjeSiTaksi** — Co-founded and developed KjeSiTaksi from September 2011 to June 2012. Planned and built iOS and Android ride-hailing apps, improving urban mobility and transportation services in Slovenia.
+  - Technologies: iOS, Android, Location Services
+
+## Technical Expertise
+- iOS Development: Swift, Objective-C, SwiftUI, UIKit, TestFlight, App Store Connect
+- Android Development: Kotlin, Java, Jetpack Compose, Material Design, Play Console
+- Development Tools: Git, Bitrise CI, Zeplin
+- Languages: Slovenian (Native), English (C1-C2), German (A1-B1)
+
+## Contact
+- LinkedIn: https://www.linkedin.com/in/luka-fin%C5%BEgar-55608831/
+- Twitter: https://twitter.com/lukafinzgar
+- Email: mailto:lukafin@gmail.com
+- Blog: /blog
+    </template>
+
+    <template id="ai-markdown-de">
+# Luka Finžgar
+
+## Zusammenfassung
+- Neugieriges Wesen, das darauf abzielt, Systeme zu entwickeln, die unser tägliches Leben erleichtern. Mit umfangreicher Erfahrung in der mobilen Entwicklung erwecke ich Ihre mobile Vision mit sauberem Code und beeindruckendem Design zum Leben.
+- Schwerpunkte: iOS, Android
+
+## Ausgewählte Projekte
+- **Toshl Finance** — Arbeite seit Dezember 2018 an der persönlichen Finanzverwaltungs-App Toshl für iOS und Android. Hilft Benutzern, ihre Finanzen durch intuitive mobile Schnittstellen effektiv zu verwalten.
+  - Technologien: iOS, Android, Mobile Entwicklung
+- **CarLock** — Mitbegründer und Entwickler von CarLock von Januar 2013 bis November 2015. Entwickelte Android- und iOS-Apps, die Fahrstil und andere Daten von einem Gerät im Auto anzeigten, um die Fahrzeugsicherheit und das Fahrerbewusstsein zu verbessern.
+  - Technologien: iOS, Android, IoT
+- **KjeSiTaksi** — Mitbegründer und Entwickler von KjeSiTaksi von September 2011 bis Juni 2012. Plante und entwickelte iOS- und Android-Taxi-Apps zur Verbesserung der städtischen Mobilität und Transportdienste in Slowenien.
+  - Technologien: iOS, Android, Standortdienste
+
+## Technische Expertise
+- iOS-Entwicklung: Swift, Objective-C, SwiftUI, UIKit, TestFlight, App Store Connect
+- Android-Entwicklung: Kotlin, Java, Jetpack Compose, Material Design, Play Console
+- Entwicklungswerkzeuge: Git, Bitrise CI, Zeplin
+- Sprachen: Slowenisch (Muttersprache), Englisch (C1-C2), Deutsch (A1-B1)
+
+## Kontakt
+- LinkedIn: https://www.linkedin.com/in/luka-fin%C5%BEgar-55608831/
+- Twitter: https://twitter.com/lukafinzgar
+- E-Mail: mailto:lukafin@gmail.com
+- Blog: /blog
+    </template>
 
     <header class="scroll-animation">
         <div class="profile-section">

--- a/index.html
+++ b/index.html
@@ -60,8 +60,16 @@ layout: none
                     </svg>
                 </button>
                 <button id="ai-toggle" class="ai-toggle" aria-label="Toggle AI mode" aria-pressed="false">
-                    <svg class="icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
-                        <path d="M6 2h8l4 4v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2zm7 1.5V7h3.5L13 3.5zM7.5 10.5h9v-1.5h-9v1.5zm0 3h9v-1.5h-9v1.5zm0 3h6v-1.5h-6v1.5z"/>
+                    <svg class="icon icon-robot icon-stroke" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true">
+                        <path d="M12 3v2"/>
+                        <rect x="5" y="5" width="14" height="12" rx="2"/>
+                        <path d="M8 10h2M14 10h2M9 14h6"/>
+                        <path d="M7 19h10"/>
+                        <path d="M9 17v2M15 17v2"/>
+                    </svg>
+                    <svg class="icon icon-human icon-stroke" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true">
+                        <path d="M12 12c2.76 0 5-2.24 5-5s-2.24-5-5-5-5 2.24-5 5 2.24 5 5 5z"/>
+                        <path d="M4 21v-1c0-3.31 3.58-6 8-6s8 2.69 8 6v1"/>
                     </svg>
                 </button>
             </div>
@@ -70,8 +78,13 @@ layout: none
 
     <section id="ai-mode" class="ai-mode-panel" aria-live="polite">
         <div class="ai-mode-header">
-            <h1 data-en="AI Mode" data-de="KI-Modus">AI Mode</h1>
-            <button id="ai-copy" class="ai-copy" data-en="Copy Markdown" data-de="Markdown kopieren">Copy Markdown</button>
+            <button id="ai-copy" class="ai-copy" data-en="Copy" data-de="Kopieren" data-translate="false" aria-label="Copy">
+                <svg class="icon icon-copy icon-stroke" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true">
+                    <rect x="9" y="9" width="13" height="13" rx="2"/>
+                    <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/>
+                </svg>
+                <span class="ai-copy-label" aria-hidden="true">Copied</span>
+            </button>
         </div>
         <pre class="ai-markdown"><code id="ai-markdown"></code></pre>
     </section>
@@ -101,7 +114,6 @@ layout: none
 - LinkedIn: https://www.linkedin.com/in/luka-fin%C5%BEgar-55608831/
 - Twitter: https://twitter.com/lukafinzgar
 - Email: mailto:lukafin@gmail.com
-- Blog: /blog
     </template>
 
     <template id="ai-markdown-de">
@@ -129,7 +141,6 @@ layout: none
 - LinkedIn: https://www.linkedin.com/in/luka-fin%C5%BEgar-55608831/
 - Twitter: https://twitter.com/lukafinzgar
 - E-Mail: mailto:lukafin@gmail.com
-- Blog: /blog
     </template>
 
     <header class="scroll-animation">

--- a/script.js
+++ b/script.js
@@ -113,12 +113,19 @@ document.addEventListener('DOMContentLoaded', () => {
                     textarea.remove();
                 }
                 const savedLanguage = localStorage.getItem('language') || 'en';
-                aiCopy.textContent = savedLanguage === 'de' ? 'Kopiert!' : 'Copied!';
+                const copiedLabel = savedLanguage === 'de' ? 'Kopiert' : 'Copied';
+                const copiedText = aiCopy.querySelector('.ai-copy-label');
+                if (copiedText) {
+                    copiedText.textContent = copiedLabel;
+                }
+                aiCopy.setAttribute('aria-label', copiedLabel);
+                aiCopy.classList.add('copied');
                 setTimeout(() => {
                     const label = aiCopy.getAttribute(`data-${savedLanguage}`);
                     if (label) {
-                        aiCopy.textContent = label;
+                        aiCopy.setAttribute('aria-label', label);
                     }
+                    aiCopy.classList.remove('copied');
                 }, 1500);
             } catch (error) {
                 console.error('Failed to copy AI markdown.', error);
@@ -179,11 +186,20 @@ function setLanguage(lang) {
 
     // Update text for all elements with a data-en or data-de attribute
     document.querySelectorAll('[data-en], [data-de]').forEach(el => {
+        if (el.getAttribute('data-translate') === 'false') return;
         const translation = el.getAttribute(`data-${lang}`);
         if (translation) {
             el.textContent = translation;
         }
     });
+
+    const aiCopy = document.getElementById('ai-copy');
+    if (aiCopy) {
+        const label = aiCopy.getAttribute(`data-${lang}`);
+        if (label) {
+            aiCopy.setAttribute('aria-label', label);
+        }
+    }
 
     updateAiMarkdown(lang);
 }

--- a/script.js
+++ b/script.js
@@ -34,6 +34,37 @@ function toggleTheme() {
     localStorage.setItem('theme', newTheme);
 }
 
+function setAiMode(enabled) {
+    document.body.classList.toggle('ai-mode', enabled);
+    localStorage.setItem('aiMode', enabled ? 'on' : 'off');
+
+    const aiToggle = document.getElementById('ai-toggle');
+    if (aiToggle) {
+        aiToggle.setAttribute('aria-pressed', enabled ? 'true' : 'false');
+    }
+}
+
+function initAiMode() {
+    const savedAiMode = localStorage.getItem('aiMode');
+    setAiMode(savedAiMode === 'on');
+}
+
+function toggleAiMode() {
+    const enabled = !document.body.classList.contains('ai-mode');
+    setAiMode(enabled);
+}
+
+function updateAiMarkdown(lang) {
+    const markdownTarget = document.getElementById('ai-markdown');
+    if (!markdownTarget) return;
+
+    const template = document.getElementById(`ai-markdown-${lang}`);
+    if (!template) return;
+
+    const content = template.content ? template.content.textContent : template.textContent;
+    markdownTarget.textContent = content.trim();
+}
+
 // Initialize when DOM is loaded
 document.addEventListener('DOMContentLoaded', () => {
     // Initialize scroll animations if they exist
@@ -46,10 +77,53 @@ document.addEventListener('DOMContentLoaded', () => {
     // Initialize theme
     initTheme();
 
+    // Initialize AI mode
+    initAiMode();
+
     // Add theme toggle event listener if the button exists
     const themeToggle = document.getElementById('theme-toggle');
     if (themeToggle) {
         themeToggle.addEventListener('click', toggleTheme);
+    }
+
+    const aiToggle = document.getElementById('ai-toggle');
+    if (aiToggle) {
+        aiToggle.addEventListener('click', toggleAiMode);
+    }
+
+    const aiCopy = document.getElementById('ai-copy');
+    if (aiCopy) {
+        aiCopy.addEventListener('click', async () => {
+            const markdownTarget = document.getElementById('ai-markdown');
+            if (!markdownTarget) return;
+
+            const text = markdownTarget.textContent;
+            try {
+                if (navigator.clipboard?.writeText) {
+                    await navigator.clipboard.writeText(text);
+                } else {
+                    const textarea = document.createElement('textarea');
+                    textarea.value = text;
+                    textarea.setAttribute('readonly', '');
+                    textarea.style.position = 'absolute';
+                    textarea.style.left = '-9999px';
+                    document.body.appendChild(textarea);
+                    textarea.select();
+                    document.execCommand('copy');
+                    textarea.remove();
+                }
+                const savedLanguage = localStorage.getItem('language') || 'en';
+                aiCopy.textContent = savedLanguage === 'de' ? 'Kopiert!' : 'Copied!';
+                setTimeout(() => {
+                    const label = aiCopy.getAttribute(`data-${savedLanguage}`);
+                    if (label) {
+                        aiCopy.textContent = label;
+                    }
+                }, 1500);
+            } catch (error) {
+                console.error('Failed to copy AI markdown.', error);
+            }
+        });
     }
 
     // Initialize hamburger menu
@@ -110,4 +184,6 @@ function setLanguage(lang) {
             el.textContent = translation;
         }
     });
+
+    updateAiMarkdown(lang);
 }

--- a/styles.css
+++ b/styles.css
@@ -296,11 +296,36 @@ section {
     border-radius: 50%;
     transition: all 0.3s ease;
     color: var(--text-color);
+    margin-left: -0.25rem;
 }
 
 .ai-toggle:hover,
 .ai-toggle[aria-pressed="true"] {
     background-color: rgba(108, 92, 231, 0.1);
+}
+
+.ai-toggle .icon-human {
+    display: none;
+}
+
+body.ai-mode .ai-toggle .icon-robot,
+.ai-toggle[aria-pressed="true"] .icon-robot {
+    display: none;
+}
+
+body.ai-mode .ai-toggle .icon-human,
+.ai-toggle[aria-pressed="true"] .icon-human {
+    display: block;
+}
+
+.theme-toggle .icon,
+.ai-toggle .icon {
+    margin-right: 0;
+}
+
+.ai-toggle .icon {
+    width: 26px;
+    height: 26px;
 }
 
 .icon {
@@ -310,6 +335,14 @@ section {
     transition: transform 0.3s ease;
     margin-right: 0.5rem;
     vertical-align: middle;
+}
+
+.icon.icon-stroke {
+    fill: none;
+    stroke: currentColor;
+    stroke-width: 1.6;
+    stroke-linecap: round;
+    stroke-linejoin: round;
 }
 
 .icon-sun {
@@ -416,7 +449,7 @@ h3 {
 .ai-mode-header {
     display: flex;
     align-items: center;
-    justify-content: space-between;
+    justify-content: flex-end;
     gap: 1rem;
     margin-bottom: 1.5rem;
 }
@@ -425,14 +458,62 @@ h3 {
     border: 1px solid var(--glass-border);
     background: var(--hover-bg);
     color: var(--text-color);
-    padding: 0.5rem 1rem;
-    border-radius: 999px;
+    width: 40px;
+    height: 40px;
+    padding: 0;
+    border-radius: 50%;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
     cursor: pointer;
     transition: all 0.3s ease;
 }
 
+.ai-copy.copied {
+    width: auto;
+    padding: 0 0.75rem;
+    border-radius: 999px;
+}
+
+.ai-copy-label {
+    display: none;
+    font-size: 0.85rem;
+    margin-left: 0.4rem;
+}
+
+.ai-copy.copied .ai-copy-label {
+    display: inline;
+}
+
 .ai-copy:hover {
     border-color: var(--accent-color);
+}
+
+.ai-copy.copied {
+    border-color: var(--accent-color);
+    box-shadow: 0 0 0 3px rgba(169, 132, 103, 0.2);
+}
+
+.ai-copy .icon {
+    width: 20px;
+    height: 20px;
+    margin-right: 0;
+}
+
+.ai-copy.copied .icon {
+    margin-right: 0.2rem;
+}
+
+.visually-hidden {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
 }
 
 .ai-markdown {
@@ -457,6 +538,10 @@ body.ai-mode .nav-links,
 body.ai-mode .hamburger-menu,
 body.ai-mode .language-switcher {
     display: none;
+}
+
+body.ai-mode .nav-content {
+    justify-content: flex-end;
 }
 
 body.ai-mode .ai-mode-panel {

--- a/styles.css
+++ b/styles.css
@@ -283,6 +283,26 @@ section {
     transform: rotate(15deg);
 }
 
+.ai-toggle {
+    background: none;
+    border: none;
+    padding: 0.5rem;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 40px;
+    height: 40px;
+    border-radius: 50%;
+    transition: all 0.3s ease;
+    color: var(--text-color);
+}
+
+.ai-toggle:hover,
+.ai-toggle[aria-pressed="true"] {
+    background-color: rgba(108, 92, 231, 0.1);
+}
+
 .icon {
     width: 24px;
     height: 24px;
@@ -380,6 +400,67 @@ h3 {
         width: 28px;
         height: 21px;
     }
+}
+
+.ai-mode-panel {
+    display: none;
+    max-width: 900px;
+    margin: 2rem auto;
+    padding: 2rem;
+    border: 1px solid var(--glass-border);
+    border-radius: 1rem;
+    background: var(--section-bg);
+    box-shadow: 0 4px 20px var(--card-shadow);
+}
+
+.ai-mode-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    margin-bottom: 1.5rem;
+}
+
+.ai-copy {
+    border: 1px solid var(--glass-border);
+    background: var(--hover-bg);
+    color: var(--text-color);
+    padding: 0.5rem 1rem;
+    border-radius: 999px;
+    cursor: pointer;
+    transition: all 0.3s ease;
+}
+
+.ai-copy:hover {
+    border-color: var(--accent-color);
+}
+
+.ai-markdown {
+    font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+    font-size: 0.95rem;
+    white-space: pre-wrap;
+    background: transparent;
+    border: none;
+    margin: 0;
+}
+
+body.ai-mode {
+    background: var(--background-color);
+}
+
+body.ai-mode header,
+body.ai-mode section:not(.ai-mode-panel) {
+    display: none;
+}
+
+body.ai-mode .nav-links,
+body.ai-mode .hamburger-menu,
+body.ai-mode .language-switcher {
+    display: none;
+}
+
+body.ai-mode .ai-mode-panel {
+    display: block;
 }
 
 /* Profile Section Styles */


### PR DESCRIPTION
### Motivation
- Provide a minimal, machine-friendly view of the site content (markdown-only) for AI agents and easy copy/export. 
- Offer the feature alongside existing theme controls and support both English and German site text.

### Description
- Added an `ai-toggle` button next to the theme switcher and an `ai-mode` panel with a copy button in `index.html` to expose markdown-only content and templates for English (`ai-markdown-en`) and German (`ai-markdown-de`).
- Implemented client-side state and behavior in `script.js`: `setAiMode`, `initAiMode`, `toggleAiMode`, `updateAiMarkdown`, language-syncing on `setLanguage`, and a copy-to-clipboard flow with a DOM fallback when `navigator.clipboard` is unavailable. 
- Added styles in `styles.css` for the toggle, the markdown panel, and an `ai-mode` body class that hides visual sections and shows only the markdown view. 
- Persisted AI mode and language choice to `localStorage`, set ARIA attributes (`aria-pressed`) for accessibility, and kept bilingual UI labels for the copy button.

### Testing
- Started a local static server with `python -m http.server 8000` and served the updated site successfully. (succeeded)
- Attempted an automated Playwright run to open the page and capture a screenshot of AI mode, but Chromium failed to launch in the environment causing the Playwright run to fail; no screenshot available. (failed)
- Performed local repository checks and recorded the changes with `git commit` after staging the modified files (`index.html`, `script.js`, `styles.css`). (succeeded)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69809e118b8c8333b545a488d060c9d8)