### PR TITLE
docs: add Hermes Agent blog post draft

### DIFF
--- a/_posts/2026-04-02-how-im-using-hermes-agent.md
+++ b/_posts/2026-04-02-how-im-using-hermes-agent.md
@@ -1,0 +1,44 @@
+---
+layout: post
+title: "How I'm using Hermes Agent"
+date: 2026-04-02 08:00:00 +0200
+categories: [ai, agents, productivity]
+---
+
+I have been spending more and more time thinking about what makes AI agents actually useful in day-to-day work, not just impressive in demos. A lot of agent tooling still feels like a thin wrapper around a chat box. It can answer questions, maybe call a few tools, and sometimes automate a narrow workflow. That is already valuable, but it is not yet the shape of system I want to live with.
+
+Hermes Agent is interesting to me because it feels much closer to a practical operator than a novelty interface. It is not only about talking to a model. It is about giving the model enough access, structure, and memory to do real work across sessions.
+
+## What I Like About It
+
+The biggest thing I appreciate is that Hermes Agent treats tool use as a first-class part of the experience.
+
+That matters because many of the tasks I actually care about are not solved by text generation alone. I want an agent that can inspect files, search code, check GitHub, work with cron jobs, read notes, interact with services, and then use all of that context to move a task forward.
+
+In practice, that changes the feeling of the system quite a lot. Instead of being a chatbot that gives me suggestions, it becomes something closer to a capable assistant that can operate in my environment.
+
+I also like that it supports persistent memory. That sounds like a small feature until you start using an agent regularly. Once the system remembers preferences, ongoing interests, and stable pieces of context, the interaction gets much smoother. You stop having to restate the same setup every time.
+
+## Why This Fits How I Work
+
+A lot of my own interests sit at the overlap of mobile development, AI systems, automation, and more dynamic interfaces. I keep paying attention to multi-agent setups, MCP-style integrations, and systems that can adapt the interface or workflow to the situation.
+
+Hermes Agent fits naturally into that direction because it is not trapped inside a single app metaphor. It can connect to different tools and surfaces, and that makes it feel more like an orchestration layer than a single-purpose product.
+
+That is much closer to how I think software will evolve over the next few years. I expect more of the value to come from systems that can coordinate tools, understand context, and decide how to act, instead of forcing users to jump manually between isolated apps.
+
+## The Part That Feels Most Promising
+
+The most promising part is not that Hermes can answer questions quickly. Plenty of systems can do that now.
+
+The more important thing is that it can help bridge the gap between intention and execution. If I want to inspect a repository, create a draft, schedule a recurring task, search my notes, or publish something with the right context, the agent can often take me much closer to the finished state instead of stopping at advice.
+
+That is the real threshold I care about: not whether an AI can sound smart, but whether it can reduce friction in actual work.
+
+## Still Early, But Already Useful
+
+I do not think agent systems are finished products yet. There are still rough edges everywhere: context handling, reliability, permissions, model quality, and knowing when the system should act on its own versus wait for confirmation.
+
+But even with those limits, Hermes Agent already feels like a glimpse of the kind of computing model I want more of. Less focus on isolated prompts. More focus on continuity, tools, memory, and useful action.
+
+That is why I keep using it. Not because it is perfect, but because it already points in a direction that feels much more aligned with how I want software to behave.


### PR DESCRIPTION
## Summary
- add a new blog post draft about using Hermes Agent
- keep the tone aligned with the existing personal blog style

## Notes
- this only opens a PR and does not publish directly to the site