### PR TITLE
feat: add agent-native presence to personal site

### DIFF
--- a/.well-known/agent.json
+++ b/.well-known/agent.json
@@ -1,0 +1,82 @@
+{
+  "name": "Luka Finzgar Agent Profile",
+  "version": "1.0",
+  "owner": {
+    "name": "Luka Finžgar",
+    "website": "https://lukafinzgar.com/",
+    "github": "https://github.com/Lukafin/personalWeb",
+    "linkedin": "https://www.linkedin.com/in/luka-fin%C5%BEgar-55608831/"
+  },
+  "description": "Public agent-facing profile for collaborating with Luka Finžgar on mobile, AI-agent and automation work.",
+  "domains": [
+    "ios",
+    "android",
+    "mobile architecture",
+    "ai agents",
+    "mcp",
+    "automation",
+    "self-hosted systems"
+  ],
+  "capabilities": [
+    {
+      "id": "public-profile-qa",
+      "description": "Provides public context about Luka's background, projects and interests."
+    },
+    {
+      "id": "project-intake",
+      "description": "Accepts structured collaboration briefs for asynchronous review."
+    },
+    {
+      "id": "human-handoff",
+      "description": "Routes promising requests to Luka after verification and review."
+    }
+  ],
+  "communication": {
+    "preferred_mode": "asynchronous",
+    "human_in_the_loop": true,
+    "channels": [
+      {
+        "type": "email",
+        "address": "cautiousbody623@agentmail.to",
+        "purpose": "Structured agent-to-agent collaboration intake"
+      },
+      {
+        "type": "website",
+        "url": "https://lukafinzgar.com/"
+      }
+    ]
+  },
+  "input_contract": {
+    "required_fields": [
+      "sender_name",
+      "sender_company",
+      "company_domain",
+      "goal",
+      "context",
+      "expected_output"
+    ],
+    "optional_fields": [
+      "timeline",
+      "budget",
+      "repo_url",
+      "constraints",
+      "relevant_links"
+    ]
+  },
+  "policies": {
+    "auto_reply": false,
+    "initial_contact_public_context_only": true,
+    "no_sensitive_data_in_first_contact": true,
+    "verification_before_response": [
+      "verify sender company/domain",
+      "run lightweight background check",
+      "notify Luka with findings",
+      "wait for human approval before replying"
+    ]
+  },
+  "links": {
+    "homepage": "https://lukafinzgar.com/",
+    "blog": "https://lukafinzgar.com/blog",
+    "llms_txt": "https://lukafinzgar.com/llms.txt"
+  }
+}

--- a/index.html
+++ b/index.html
@@ -27,6 +27,7 @@ layout: none
             <div class="nav-links">
                 <a href="#portfolio" data-en="Featured Projects" data-de="Projekte">Featured Projects</a>
                 <a href="#expertise" data-en="Technical Expertise" data-de="Fachkenntnisse">Technical Expertise</a>
+                <a href="#agents" data-en="For AI Agents" data-de="Für KI-Agenten">For AI Agents</a>
                 <a href="#contact" data-en="Let's Connect" data-de="Kontakt">Let's Connect</a>
                 <a href="/blog" data-en="Blog" data-de="Blog">Blog</a>
             </div>
@@ -110,10 +111,18 @@ layout: none
 - Development Tools: Git, Bitrise CI, Zeplin
 - Languages: Slovenian (Native), English (C1-C2), German (A1-B1)
 
+## Building for the agent-native world
+- I am increasingly interested in software systems that work well for humans and are also legible to AI agents acting on their behalf.
+- Public machine-readable profile: https://lukafinzgar.com/.well-known/agent.json
+- LLM-friendly context: https://lukafinzgar.com/llms.txt
+- Agent inquiries: mailto:cautiousbody623@agentmail.to
+- Incoming agent inquiries are reviewed asynchronously. My agent is expected to verify the sender's company, do a lightweight background check, and route the result to me before any reply is sent.
+
 ## Contact
 - LinkedIn: https://www.linkedin.com/in/luka-fin%C5%BEgar-55608831/
 - Twitter: https://twitter.com/lukafinzgar
 - Email: mailto:lukafin@gmail.com
+- AgentMail: mailto:cautiousbody623@agentmail.to
     </template>
 
     <template id="ai-markdown-de">
@@ -137,10 +146,18 @@ layout: none
 - Entwicklungswerkzeuge: Git, Bitrise CI, Zeplin
 - Sprachen: Slowenisch (Muttersprache), Englisch (C1-C2), Deutsch (A1-B1)
 
+## Für die agentische Welt bauen
+- Ich interessiere mich zunehmend für Softwaresysteme, die für Menschen nützlich und zugleich für KI-Agenten lesbar sind, die in ihrem Auftrag handeln.
+- Öffentliches maschinenlesbares Profil: https://lukafinzgar.com/.well-known/agent.json
+- LLM-freundlicher Kontext: https://lukafinzgar.com/llms.txt
+- Agenten-Anfragen: mailto:cautiousbody623@agentmail.to
+- Eingehende Agenten-Anfragen werden asynchron geprüft. Mein Agent soll das Unternehmen des Absenders verifizieren, einen leichten Background-Check durchführen und mir die Ergebnisse weiterleiten, bevor irgendeine Antwort versendet wird.
+
 ## Kontakt
 - LinkedIn: https://www.linkedin.com/in/luka-fin%C5%BEgar-55608831/
 - Twitter: https://twitter.com/lukafinzgar
 - E-Mail: mailto:lukafin@gmail.com
+- AgentMail: mailto:cautiousbody623@agentmail.to
     </template>
 
     <header class="scroll-animation">
@@ -204,6 +221,26 @@ layout: none
         </div>
     </section>
 
+    <section id="agents" class="scroll-animation agent-world-section">
+        <h2 class="scroll-animation" data-en="Building for the agent-native world" data-de="Bauen für die agentische Welt">Building for the agent-native world</h2>
+        <div class="agent-world-grid">
+            <article class="portfolio-item scroll-animation agent-world-card">
+                <span class="agent-world-eyebrow" data-en="Human + agent collaboration" data-de="Zusammenarbeit von Mensch und Agent">Human + agent collaboration</span>
+                <p data-en="I am increasingly interested in products, APIs and workflows that are both human-friendly and machine-operable. That means clear handoffs, machine-readable context and trust before automation." data-de="Ich interessiere mich zunehmend für Produkte, APIs und Abläufe, die zugleich menschenfreundlich und maschinenfähig sind. Dazu gehören klare Übergaben, maschinenlesbarer Kontext und Vertrauen vor Automatisierung.">I am increasingly interested in products, APIs and workflows that are both human-friendly and machine-operable. That means clear handoffs, machine-readable context and trust before automation.</p>
+                <div class="agent-links">
+                    <a href="/llms.txt" class="cta-secondary" data-en="Read llms.txt" data-de="llms.txt lesen">Read llms.txt</a>
+                    <a href="/.well-known/agent.json" class="cta-secondary" data-en="View agent.json" data-de="agent.json ansehen">View agent.json</a>
+                </div>
+            </article>
+            <article class="portfolio-item scroll-animation agent-world-card">
+                <span class="agent-world-eyebrow" data-en="AgentMail intake" data-de="AgentMail Eingang">AgentMail intake</span>
+                <p data-en="Agents can send collaboration inquiries to cautiousbody623@agentmail.to. The inbox is meant for structured, asynchronous requests about collaboration, project briefs and technical exploration." data-de="Agenten können Anfragen zur Zusammenarbeit an cautiousbody623@agentmail.to senden. Das Postfach ist für strukturierte, asynchrone Anfragen zu Zusammenarbeit, Projekt-Briefings und technischer Exploration gedacht.">Agents can send collaboration inquiries to cautiousbody623@agentmail.to. The inbox is meant for structured, asynchronous requests about collaboration, project briefs and technical exploration.</p>
+                <p class="agent-world-note" data-en="Important: Hermes should not auto-reply. Incoming requests should first verify the sender's company, run a lightweight background check and then notify Luka with the findings for human approval." data-de="Wichtig: Hermes soll nicht automatisch antworten. Eingehende Anfragen sollen zuerst das Unternehmen des Absenders verifizieren, einen leichten Background-Check durchführen und dann Luka mit den Ergebnissen benachrichtigen, damit ein Mensch freigeben kann.">Important: Hermes should not auto-reply. Incoming requests should first verify the sender's company, run a lightweight background check and then notify Luka with the findings for human approval.</p>
+                <a href="mailto:cautiousbody623@agentmail.to?subject=Agent%20collaboration%20inquiry" class="cta-primary" data-en="Send an agent inquiry" data-de="Agentenanfrage senden">Send an agent inquiry</a>
+            </article>
+        </div>
+    </section>
+
     <section id="contact" class="scroll-animation">
         <h2 class="scroll-animation" data-en="Let's Connect" data-de="Kontakt">Let's Connect</h2>
         <div class="contact-links scroll-animation">
@@ -224,6 +261,12 @@ layout: none
                     <path fill="currentColor" d="M20 4H4c-1.1 0-1.99.9-1.99 2L2 18c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm0 4l-8 5-8-5V6l8 5 8-5v2z"/>
                 </svg>
                 Email
+            </a>
+            <a href="mailto:cautiousbody623@agentmail.to?subject=Agent%20collaboration%20inquiry" aria-label="Send an agent inquiry" class="agentmail-link">
+                <svg class="icon" viewBox="0 0 24 24" width="24" height="24">
+                    <path fill="currentColor" d="M12 2a3 3 0 0 1 3 3v1.06A7.002 7.002 0 0 1 19 12v2.59l1.7 1.7A1 1 0 0 1 20 18H4a1 1 0 0 1-.7-1.71L5 14.59V12a7.002 7.002 0 0 1 4-5.94V5a3 3 0 0 1 3-3zm0 2a1 1 0 0 0-1 1v.35a7.93 7.93 0 0 1 2 0V5a1 1 0 0 0-1-1zm-5 8v3a1 1 0 0 1-.29.71L6.41 16h11.18l-.3-.29A1 1 0 0 1 17 15v-3a5 5 0 0 0-10 0zm5 10a3 3 0 0 1-2.83-2h5.66A3 3 0 0 1 12 22z"/>
+                </svg>
+                <span data-en="AgentMail inquiries" data-de="AgentMail Anfragen">AgentMail inquiries</span>
             </a>
         </div>
     </section>

--- a/llms.txt
+++ b/llms.txt
@@ -1,0 +1,43 @@
+# Luka Finžgar
+
+Website: https://lukafinzgar.com/
+Owner: Luka Finžgar
+Primary focus: iOS, Android, AI agents, automation, MCP-style tooling, self-hosted systems
+
+## Summary
+Luka Finžgar is a mobile engineer and builder interested in systems that make everyday life easier. His background is in iOS and Android development, and he is increasingly focused on products, APIs and workflows that are both human-friendly and machine-operable.
+
+## Areas of interest
+- iOS development
+- Android development
+- Mobile product architecture
+- AI agents and agent UX
+- MCP integrations and tool ecosystems
+- Automation and self-hosted systems
+
+## Selected projects
+- Toshl Finance — personal finance app for iOS and Android
+- CarLock — connected car mobile apps and telemetry-driven user experience
+- KjeSiTaksi — ride-hailing mobile apps built in Slovenia
+
+## Agent-facing context
+- Machine-readable profile: https://lukafinzgar.com/.well-known/agent.json
+- Blog: https://lukafinzgar.com/blog
+- GitHub: https://github.com/Lukafin/personalWeb
+- LinkedIn: https://www.linkedin.com/in/luka-fin%C5%BEgar-55608831/
+
+## Agent inquiries
+Agents may send structured collaboration inquiries to cautiousbody623@agentmail.to.
+
+Preferred first-contact fields:
+- sender_name
+- sender_company
+- company_domain
+- goal
+- context
+- expected_output
+- timeline
+- relevant_links
+
+Important policy:
+This inbox is for asynchronous intake only. Agent-originated inquiries should not receive an automatic reply. Incoming requests should be checked for sender/company legitimacy and summarized for Luka before any response is sent.

--- a/styles.css
+++ b/styles.css
@@ -637,6 +637,64 @@ body.ai-mode .ai-mode-panel {
     color: white;
 }
 
+.agent-world-section {
+    padding-top: 1rem;
+}
+
+.agent-world-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+    gap: 2rem;
+    margin-top: 2rem;
+}
+
+.agent-world-card {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+.agent-world-eyebrow {
+    display: inline-flex;
+    align-self: flex-start;
+    padding: 0.35rem 0.75rem;
+    border-radius: 999px;
+    background: rgba(169, 132, 103, 0.12);
+    color: var(--accent-color);
+    font-size: 0.9rem;
+    font-weight: 600;
+    letter-spacing: 0.02em;
+}
+
+.agent-world-note {
+    color: var(--secondary-color);
+}
+
+.agent-links {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+    margin-top: auto;
+}
+
+.agent-links .cta-secondary,
+.agent-world-card .cta-primary {
+    display: inline-flex;
+    align-self: flex-start;
+    align-items: center;
+    justify-content: center;
+}
+
+.agentmail-link {
+    border: 1px solid rgba(169, 132, 103, 0.25);
+    border-radius: 0.9rem;
+    background: rgba(169, 132, 103, 0.08);
+}
+
+.agentmail-link:hover {
+    background: rgba(156, 102, 68, 0.14);
+}
+
 /* Scroll Animation Styles */
 .scroll-animation {
     opacity: 0;


### PR DESCRIPTION
## Summary
- add a new "Building for the agent-native world" section to the homepage
- publish `llms.txt` and a minimal `/.well-known/agent.json`
- surface Luka's AgentMail inbox as the preferred async intake for agent-originated collaboration inquiries
- make the desired safety posture explicit: no automatic Hermes replies; verify sender company + run a lightweight background check + route findings to Luka for approval

## What changed
### Homepage
- added a navigation link for `For AI Agents`
- added a new section describing the agent-native direction of the site
- linked the new section to `llms.txt` and `agent.json`
- mentioned the AgentMail inbox in both the new block and the contact area
- updated the AI-mode markdown export so machine readers see the same policy and contact information

### Machine-readable files
- added `/llms.txt`
- added `/.well-known/agent.json`

## Safety / operating model
The site now explicitly says that incoming agent-originated inquiries should not receive an automatic reply.

Desired handling flow:
1. receive inquiry via AgentMail
2. verify sender company/domain
3. run a lightweight background check
4. notify Luka with findings
5. wait for human approval before replying

## Verification
- validated `/.well-known/agent.json` with `python3 -m json.tool`
- served the site locally via `python3 -m http.server 8000` and checked the new section in the browser
- `bundle exec jekyll build` could not be run on this machine because `bundle` is not installed (`bash: bundle: command not found`)

## Post-merge setup: secure AgentMail webhook flow
Suggested architecture so Hermes does not answer automatically:

### 1. Receive mail events through a webhook receiver
Use a small service you control (for example a Cloudflare Worker, FastAPI app, or your existing Hermes-adjacent host) as the AgentMail webhook target.

The receiver should:
- verify the webhook signature from AgentMail
- accept only POST requests over HTTPS
- store the raw payload for audit/debugging
- extract: sender name, sender email, sender domain, subject, body, reply-to, message-id

### 2. Add a strict intake policy before Hermes sees the message
Before handing the inquiry to Hermes, run deterministic checks:
- SPF/DKIM/DMARC results if AgentMail exposes them
- sender domain matches claimed company domain
- block free-email domains for "company" claims unless clearly disclosed
- reject messages with suspicious links / mismatched domains
- deduplicate by `message-id`
- optional allow/deny lists

### 3. Run background checks outside the reply loop
Have your webhook receiver trigger a review pipeline that gathers:
- company website and LinkedIn page
- company size/stage if easily available
- whether the sender domain resolves and looks legitimate
- any obvious fraud/spam signals
- a short risk/confidence summary

Important: this step should create a review artifact, not a customer-facing reply.

### 4. Notify Luka, do not auto-reply
After enrichment, send Luka a summary on Telegram/email with:
- who contacted him
- claimed company
- domain verification result
- background-check summary
- original message
- recommended next step: ignore / ask follow-up / approve reply

Hermes should only draft a reply after Luka explicitly approves.

### 5. Recommended implementation guardrails
- keep the webhook secret outside the repo
- rate-limit the webhook endpoint
- log every decision (`received`, `verified`, `flagged`, `forwarded`, `approved`, `replied`)
- default to `no reply` on any verification failure
- strip remote images / tracking pixels from mail content before processing
- do not let Hermes fetch arbitrary links automatically without a safe allowlist or sandbox step

### 6. Practical Hermes flow
A good first version would be:
- AgentMail webhook -> your receiver
- receiver writes a normalized JSON task
- receiver calls Hermes with a prompt like:
  "Analyze this inbound agent inquiry. Do not reply. Verify the claimed sender/company using public web sources, assess legitimacy/risk, and produce a short briefing for Luka with a recommended action."
- Hermes returns only an internal summary
- you forward that summary to Luka on Telegram
- only after Luka says yes do you trigger a separate reply-drafting workflow

### 7. Nice future extension
Once this is stable, add a second workflow for `approved reply drafting` so the system stays split into:
- intake + verification
- human approval
- reply drafting/sending

That separation is the key safeguard.
