### PR TITLE
docs: add short post about artists infographic archive

### DIFF
--- a/_posts/2026-04-14-a-small-ai-made-archive-of-daily-infographics.md
+++ b/_posts/2026-04-14-a-small-ai-made-archive-of-daily-infographics.md
@@ -1,12 +1,12 @@
 ---
 layout: post
-title: "A small AI-made archive of daily infographics"
+title: "A small archive of daily infographics"
 date: 2026-04-14 10:00:00 +0100
-categories: [ai, side-project]
+categories: [side-project]
 ---
 
-I put together a small public page that archives daily birthday infographics my AI agent generates: [artists infographic archive](https://lukafin.github.io/artists-infographic-archive/).
+I put together a small public page that archives daily birthday infographics: [artists infographic archive](https://lukafin.github.io/artists-infographic-archive/).
 
-The idea is simple: every day the agent picks a notable artist or scientist who has a birthday, gathers a few sources, and turns that into a short Slovenian infographic made for kids. The page keeps both today’s image and older ones in a lightweight gallery, so it becomes a fun little archive over time.
+The idea is simple: every day it highlights a notable artist or scientist who has a birthday, gathers a few sources, and turns that into a short Slovenian infographic made for kids. The page keeps both today’s image and older ones in a lightweight gallery, so it becomes a fun little archive over time.
 
-It is one of those tiny projects I like because it makes AI feel a bit more concrete and playful. Instead of being just another chat window, the agent quietly does a small piece of creative work in the background and leaves behind something browsable and useful.
+It is one of those tiny projects I like because it feels concrete and playful. Instead of disappearing into a feed, each day leaves behind something browsable and useful.

--- a/_posts/2026-04-14-a-small-ai-made-archive-of-daily-infographics.md
+++ b/_posts/2026-04-14-a-small-ai-made-archive-of-daily-infographics.md
@@ -1,0 +1,12 @@
+---
+layout: post
+title: "A small AI-made archive of daily infographics"
+date: 2026-04-14 10:00:00 +0100
+categories: [ai, side-project]
+---
+
+I put together a small public page that archives daily birthday infographics my AI agent generates: [artists infographic archive](https://lukafin.github.io/artists-infographic-archive/).
+
+The idea is simple: every day the agent picks a notable artist or scientist who has a birthday, gathers a few sources, and turns that into a short Slovenian infographic made for kids. The page keeps both today’s image and older ones in a lightweight gallery, so it becomes a fun little archive over time.
+
+It is one of those tiny projects I like because it makes AI feel a bit more concrete and playful. Instead of being just another chat window, the agent quietly does a small piece of creative work in the background and leaves behind something browsable and useful.


### PR DESCRIPTION
## Summary
- add a short, plain-language blog post about the AI-generated artists infographic archive
- link to the public archive page and explain the idea in a lightweight way

## Verification
- checked the live archive page content and structure
- matched the new post to the existing Jekyll post format in this repo
- local `bundle exec jekyll build` could not be run here because Ruby/Bundler are not installed on this machine