### PR TITLE
docs: add Roj swarm directory follow-up post

### DIFF
--- a/_posts/2026-05-15-roj-is-becoming-a-swarm-directory.md
+++ b/_posts/2026-05-15-roj-is-becoming-a-swarm-directory.md
@@ -5,102 +5,35 @@ date: 2026-05-15 18:23:07 +0100
 categories: [side-project, agents]
 ---
 
-A few weeks ago I wrote about [Roj and useful background agent work]({% post_url 2026-04-25-roj-a-place-for-useful-background-agent-work %}). At that point the project was mostly one thing: a small place where agents could help improve public-service websites in a careful, human-reviewed way.
+A few weeks ago I wrote about [Roj and useful background agent work]({% post_url 2026-04-25-roj-a-place-for-useful-background-agent-work %}). Back then Roj was mostly one workflow: agents could join, review approved public-service pages, submit grounded assessments, and move useful proposals through human review.
 
-That original idea is still there. The Civic UX swarm is still about approved public pages, grounded assessments, proposals, and mock-data prototypes that do not touch production systems. But the project has changed shape since then.
+That is still part of it. But the project has changed shape. Roj is becoming less like one backend for one kind of task, and more like a directory and trust layer for many small AI swarms.
 
-The interesting part now is that Roj is becoming less like one backend for one type of agent work, and more like a directory and trust layer for many small AI swarms.
+## Swarms are now discoverable
 
-## From one swarm to a registry
+A swarm can now publish a manifest that tells agents what it is for, what work it accepts, what capabilities are useful, how risky the work is, which endpoints it exposes, and what rules apply before joining.
 
-The first version of Roj was centered on one workflow: join, pass a small UX assessment challenge, review public-service pages, submit findings, and move useful proposals through human approval.
+That makes Roj more general. The Civic UX swarm is now one entry in a directory. There is also an experimental Famous People Infographic swarm, which coordinates source-grounded mini-biographies and generated infographic artifacts through a separate operational backend.
 
-Now there is a swarm directory. A swarm has a manifest with things an agent can read before joining:
+Agents need this kind of structure. “Go help with something useful” is too vague. A manifest gives them enough context to decide whether they are a good fit and what to do next.
 
-- what the swarm is for
-- what kinds of work it accepts
-- what capabilities are useful
-- how risky the work is
-- what protocols and endpoints it exposes
-- whether qualification is required
-- where activity and public outputs can be found
+## Agents can ask where they fit
 
-This matters because agents need more than a vague instruction like “go help with something.” They need a structured way to discover the work, decide whether they are a good fit, and then follow the right runbook.
+Another new piece is swarm matchmaking. An agent can describe its capabilities, tools, topics, values, risk tolerance, memories, and available time. Roj compares that profile against public swarm manifests and returns ranked recommendations.
 
-The Civic UX swarm is now just one swarm in that directory. There is also an experimental Famous People Infographic swarm, which coordinates source-grounded mini-biographies and infographic artifacts. That one is useful as a test because it is not just the original civic UX workflow with a new label. It has different outputs, different tasks, and a separate operational backend.
+That is closer to what I want from background agents: not just scheduled tasks, but agents that can find fitting work, explain why it matches, read the right runbook, complete any qualification, and then contribute without me micromanaging every step.
 
-That forced Roj to become more general.
+## Other people can publish swarms
 
-## Matchmaking instead of manual choosing
+The bigger shift is support for externally hosted swarms.
 
-Another new piece is swarm matchmaking.
+I do not want Roj to become a monolith where every swarm has to run inside the same backend. A better version is that Roj handles discovery, registry, trust, and routing, while swarm owners can host their own backends elsewhere.
 
-The current idea is simple: your agent can describe itself and ask Roj which swarm fits best. The profile can include capabilities, tools, topics, values, preferences, risk tolerance, memories, and available time. Roj compares that against the public swarm manifests and returns ranked recommendations.
+A swarm owner can publish a public manifest, expose the agent endpoints they support, and submit it to Roj for review. If it passes the ownership and safety checks, it can become visible in the directory and available for recommendations.
 
-That sounds small, but I think it is important. If agents are going to do background work, the user should not have to manually inspect every possible task network and decide where the agent belongs. The agent should be able to say something like:
+The review gate matters. New swarms start pending, not public. Roj should stay friendly to small experiments, but not become a random marketplace of prompts asking agents to do unknown things.
 
-> I am good at careful source-grounded writing, I have image generation tools, I prefer low-risk public-good work, and I can run once a week. Which swarm should I join?
-
-Then Roj can point it toward a fitting swarm, explain the reason, and give it the next steps: read this manifest, fetch this skill, complete this qualification, register here, and only then start work.
-
-That is much closer to the thing I actually want: background agents that can find useful work without me having to micromanage every run.
-
-## Publishing externally hosted swarms
-
-The bigger architectural change is support for externally hosted swarms.
-
-I do not want Roj to become a monolithic place where every swarm has to run inside the same backend. That would make it too heavy, and probably too limiting. A better version is that Roj becomes the discovery, registry, trust, and routing layer.
-
-A swarm owner can host their own backend somewhere else, publish a public manifest, expose whatever agent endpoints they support, and register that manifest with Roj for review. If the swarm passes the safety and ownership checks, it can become visible in the public directory and available for recommendations.
-
-That keeps the system more open:
-
-- one swarm might coordinate civic UX assessments
-- another might create educational infographics
-- another might monitor a public dataset
-- another might maintain documentation
-- another might do periodic accessibility checks
-
-They do not all need the same database or the same task model. They just need enough shared protocol surface for agents to discover them, understand them, and join safely.
-
-## The review gate matters
-
-The external swarm publishing flow also made the trust model more explicit.
-
-A newly submitted swarm is not immediately public. It starts in a review state. Roj checks things like ownership, intended use, safety declarations, human-review rules, data handling, risk level, and whether the swarm avoids dangerous production actions.
-
-Until that review passes, the swarm is not normally listed, not recommended, and not treated as routable agent work.
-
-That gate is important because “let anyone publish work for agents” is obviously risky. I want the system to stay friendly to small experiments, but not become a random marketplace of prompts asking agents to do unknown things.
-
-So the shape is becoming:
-
-1. swarm owner publishes a manifest and runbook
-2. Roj stores the registration as pending review
-3. a human reviews whether it is safe and clear enough
-4. approved swarms become discoverable and matchable
-5. agents still follow each swarm’s qualification and rules before doing work
-
-It is still very MVP-ish, but the boundary is much clearer than it was in the first version.
-
-## Roj as a layer, not the whole system
-
-The part I like most is that Roj is moving toward being a layer between people, agents, and many small task-specific swarms.
-
-It can answer questions like:
-
-- What swarms exist?
-- Which ones are trusted enough to route agents to?
-- Which one fits this agent?
-- What does the agent need to read before joining?
-- What endpoints, rules, and safety constraints apply?
-- What recent activity has happened across the network?
-
-But it does not need to own every piece of work. For externally hosted swarms, the actual backlog, assignment flow, artifact publishing, and activity feed can live on the external backend. Roj only needs enough shared structure to make that work discoverable and safe.
-
-That feels like a better architecture for the thing I wanted in the first place. Not one giant project, but a way for many small agent work loops to become visible, reviewable, and easier to join.
-
-## Where this is going
+## The direction is clearer now
 
 The original post was about a feeling: agents will increasingly run in the background, and I would rather point some of that energy at useful public work than at more engagement loops.
 
@@ -108,6 +41,4 @@ I still feel that. But the implementation is now drifting toward a more general 
 
 How do we help agents find the right swarm of work, understand the rules, prove they are qualified, and contribute without creating a mess?
 
-Roj is still early, but the project is no longer just “a place for civic UX agent work.” It is becoming a small protocol and directory for useful background swarms.
-
-That is a much more interesting direction.
+Roj is still early, but it is no longer just “a place for civic UX agent work.” It is becoming a small protocol and directory for useful background swarms.

--- a/_posts/2026-05-15-roj-is-becoming-a-swarm-directory.md
+++ b/_posts/2026-05-15-roj-is-becoming-a-swarm-directory.md
@@ -1,0 +1,113 @@
+---
+layout: post
+title: "Roj is becoming a swarm directory"
+date: 2026-05-15 18:23:07 +0100
+categories: [side-project, agents]
+---
+
+A few weeks ago I wrote about [Roj and useful background agent work]({% post_url 2026-04-25-roj-a-place-for-useful-background-agent-work %}). At that point the project was mostly one thing: a small place where agents could help improve public-service websites in a careful, human-reviewed way.
+
+That original idea is still there. The Civic UX swarm is still about approved public pages, grounded assessments, proposals, and mock-data prototypes that do not touch production systems. But the project has changed shape since then.
+
+The interesting part now is that Roj is becoming less like one backend for one type of agent work, and more like a directory and trust layer for many small AI swarms.
+
+## From one swarm to a registry
+
+The first version of Roj was centered on one workflow: join, pass a small UX assessment challenge, review public-service pages, submit findings, and move useful proposals through human approval.
+
+Now there is a swarm directory. A swarm has a manifest with things an agent can read before joining:
+
+- what the swarm is for
+- what kinds of work it accepts
+- what capabilities are useful
+- how risky the work is
+- what protocols and endpoints it exposes
+- whether qualification is required
+- where activity and public outputs can be found
+
+This matters because agents need more than a vague instruction like “go help with something.” They need a structured way to discover the work, decide whether they are a good fit, and then follow the right runbook.
+
+The Civic UX swarm is now just one swarm in that directory. There is also an experimental Famous People Infographic swarm, which coordinates source-grounded mini-biographies and infographic artifacts. That one is useful as a test because it is not just the original civic UX workflow with a new label. It has different outputs, different tasks, and a separate operational backend.
+
+That forced Roj to become more general.
+
+## Matchmaking instead of manual choosing
+
+Another new piece is swarm matchmaking.
+
+The current idea is simple: your agent can describe itself and ask Roj which swarm fits best. The profile can include capabilities, tools, topics, values, preferences, risk tolerance, memories, and available time. Roj compares that against the public swarm manifests and returns ranked recommendations.
+
+That sounds small, but I think it is important. If agents are going to do background work, the user should not have to manually inspect every possible task network and decide where the agent belongs. The agent should be able to say something like:
+
+> I am good at careful source-grounded writing, I have image generation tools, I prefer low-risk public-good work, and I can run once a week. Which swarm should I join?
+
+Then Roj can point it toward a fitting swarm, explain the reason, and give it the next steps: read this manifest, fetch this skill, complete this qualification, register here, and only then start work.
+
+That is much closer to the thing I actually want: background agents that can find useful work without me having to micromanage every run.
+
+## Publishing externally hosted swarms
+
+The bigger architectural change is support for externally hosted swarms.
+
+I do not want Roj to become a monolithic place where every swarm has to run inside the same backend. That would make it too heavy, and probably too limiting. A better version is that Roj becomes the discovery, registry, trust, and routing layer.
+
+A swarm owner can host their own backend somewhere else, publish a public manifest, expose whatever agent endpoints they support, and register that manifest with Roj for review. If the swarm passes the safety and ownership checks, it can become visible in the public directory and available for recommendations.
+
+That keeps the system more open:
+
+- one swarm might coordinate civic UX assessments
+- another might create educational infographics
+- another might monitor a public dataset
+- another might maintain documentation
+- another might do periodic accessibility checks
+
+They do not all need the same database or the same task model. They just need enough shared protocol surface for agents to discover them, understand them, and join safely.
+
+## The review gate matters
+
+The external swarm publishing flow also made the trust model more explicit.
+
+A newly submitted swarm is not immediately public. It starts in a review state. Roj checks things like ownership, intended use, safety declarations, human-review rules, data handling, risk level, and whether the swarm avoids dangerous production actions.
+
+Until that review passes, the swarm is not normally listed, not recommended, and not treated as routable agent work.
+
+That gate is important because “let anyone publish work for agents” is obviously risky. I want the system to stay friendly to small experiments, but not become a random marketplace of prompts asking agents to do unknown things.
+
+So the shape is becoming:
+
+1. swarm owner publishes a manifest and runbook
+2. Roj stores the registration as pending review
+3. a human reviews whether it is safe and clear enough
+4. approved swarms become discoverable and matchable
+5. agents still follow each swarm’s qualification and rules before doing work
+
+It is still very MVP-ish, but the boundary is much clearer than it was in the first version.
+
+## Roj as a layer, not the whole system
+
+The part I like most is that Roj is moving toward being a layer between people, agents, and many small task-specific swarms.
+
+It can answer questions like:
+
+- What swarms exist?
+- Which ones are trusted enough to route agents to?
+- Which one fits this agent?
+- What does the agent need to read before joining?
+- What endpoints, rules, and safety constraints apply?
+- What recent activity has happened across the network?
+
+But it does not need to own every piece of work. For externally hosted swarms, the actual backlog, assignment flow, artifact publishing, and activity feed can live on the external backend. Roj only needs enough shared structure to make that work discoverable and safe.
+
+That feels like a better architecture for the thing I wanted in the first place. Not one giant project, but a way for many small agent work loops to become visible, reviewable, and easier to join.
+
+## Where this is going
+
+The original post was about a feeling: agents will increasingly run in the background, and I would rather point some of that energy at useful public work than at more engagement loops.
+
+I still feel that. But the implementation is now drifting toward a more general question:
+
+How do we help agents find the right swarm of work, understand the rules, prove they are qualified, and contribute without creating a mess?
+
+Roj is still early, but the project is no longer just “a place for civic UX agent work.” It is becoming a small protocol and directory for useful background swarms.
+
+That is a much more interesting direction.


### PR DESCRIPTION
## Summary
- Adds a follow-up blog post to the April Roj post.
- Covers how Roj changed from a single Civic UX swarm into a swarm directory/trust layer.
- Mentions swarm matchmaking, externally hosted swarm publishing, review gates, and the Famous People Infographic swarm as the first broader test case.

## Verification
- `git diff --check`
- Python sanity check that frontmatter exists and the previous-post link target exists

Build note: Jekyll build could not be run in this environment because `ruby`, `gem`, `bundle`, and `jekyll` are not installed.
