### PR TITLE
Add RSS feed for blog

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -11,6 +11,8 @@
     <link rel="icon" type="image/png" sizes="16x16" href="{{ '/favicon-16x16.png' | relative_url }}">
     <link rel="shortcut icon" href="{{ '/favicon.ico' | relative_url }}">
     <link rel="stylesheet" href="{{ '/styles.css' | relative_url }}">
+    <link rel="alternate" type="application/rss+xml" title="{{ site.title | xml_escape }} RSS" href="{{ '/rss.xml' | absolute_url }}">
+    <link rel="alternate" type="application/atom+xml" title="{{ site.title | xml_escape }} Atom" href="{{ '/feed.xml' | absolute_url }}">
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@500;650;800;900&display=swap" rel="stylesheet">
     <script src="{{ '/script.js' | relative_url }}" defer></script>
     <!-- Google tag (gtag.js) -->

--- a/blog/index.html
+++ b/blog/index.html
@@ -7,6 +7,10 @@ hide_language_switcher: true
 <div class="blog-list">
     <h1 data-en="Latest Blog Posts" data-de="Neueste Blogbeiträge">Latest Blog Posts</h1>
 
+    <div class="blog-actions" aria-label="Blog subscription options">
+      <a class="rss-link" href="{{ '/rss.xml' | relative_url }}" type="application/rss+xml">RSS feed</a>
+    </div>
+
     <ul>
       {% for post in site.posts %}
         <li>

--- a/rss.xml
+++ b/rss.xml
@@ -1,0 +1,23 @@
+---
+layout: null
+---
+<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <title>{{ site.title | xml_escape }}</title>
+    <description>{{ site.description | xml_escape }}</description>
+    <link>{{ '/' | absolute_url }}</link>
+    <atom:link href="{{ '/rss.xml' | absolute_url }}" rel="self" type="application/rss+xml" />
+    <language>en</language>
+    <lastBuildDate>{{ site.time | date_to_rfc822 }}</lastBuildDate>
+    {% for post in site.posts limit:20 %}
+    <item>
+      <title>{{ post.title | xml_escape }}</title>
+      <description>{{ post.excerpt | strip_html | normalize_whitespace | xml_escape }}</description>
+      <pubDate>{{ post.date | date_to_rfc822 }}</pubDate>
+      <link>{{ post.url | absolute_url }}</link>
+      <guid isPermaLink="true">{{ post.url | absolute_url }}</guid>
+    </item>
+    {% endfor %}
+  </channel>
+</rss>

--- a/styles.css
+++ b/styles.css
@@ -1173,6 +1173,34 @@ body::before {
     font-weight: 850;
 }
 
+.blog-actions {
+    display: flex;
+    justify-content: flex-end;
+    margin: 12px 0 0;
+}
+
+.rss-link {
+    display: inline-flex;
+    align-items: center;
+    min-height: 38px;
+    padding: 0 16px;
+    border: 1px solid currentColor;
+    background: var(--warm-cream);
+    color: var(--warm-page-ink);
+    text-decoration: none;
+    font-size: 12px;
+    line-height: 1;
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    font-weight: 850;
+}
+
+.rss-link:hover {
+    background: var(--warm-amber);
+    text-decoration: underline;
+    text-underline-offset: 3px;
+}
+
 .blog-list ul {
     list-style: none;
     padding: 0;


### PR DESCRIPTION
## Summary
- add a Jekyll-rendered RSS 2.0 feed at /rss.xml
- add RSS and existing Atom autodiscovery links in the default layout
- add a subtle RSS feed link on the blog index matching the warm card design

## Verification
- built the Jekyll site via Docker with `bundle exec jekyll build`
- parsed generated `_site/rss.xml` and `_site/feed.xml` as valid XML
- verified the blog page contains RSS/Atom autodiscovery and visible RSS link
- clicked the RSS link in a local browser preview
- ran `git diff --check`