### PR TITLE
Remove blog nav divider before theme toggle

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -34,7 +34,7 @@
                 <a href="{{ '/blog/' | relative_url }}" data-en="Blog" data-de="Blog">Blog</a>
                 <a href="{{ '/#contact' | relative_url }}" data-en="Contact" data-de="Kontakt">Contact</a>
             </div>
-            <div class="nav-controls" aria-label="Display controls">
+            <div class="nav-controls{% if page.hide_language_switcher or page.layout == 'post' %} nav-controls--solo{% endif %}" aria-label="Display controls">
                 {% unless page.hide_language_switcher or page.layout == 'post' %}
                 <button id="en-lang" class="lang-btn" type="button" aria-label="Switch to English">EN</button>
                 <button id="de-lang" class="lang-btn" type="button" aria-label="Switch to German">DE</button>

--- a/styles.css
+++ b/styles.css
@@ -1110,6 +1110,11 @@ body::before {
     border-left: 1px solid rgba(255, 255, 255, 0.18);
 }
 
+.card-nav .nav-controls--solo {
+    padding-left: 0;
+    border-left: 0;
+}
+
 .card-nav .theme-toggle {
     width: 34px;
     height: 34px;


### PR DESCRIPTION
## Summary
- add a solo nav-controls state when the language switcher is hidden
- remove the left divider/padding before the theme toggle on blog/post pages
- keep the existing divider behavior for navs that still include language controls

## Verification
- built the Jekyll site via Docker with `bundle exec jekyll build`
- visually checked local preview at `/blog/`: divider is gone and nav alignment remains intact
- ran `git diff --check`