### PR TITLE
Add blog search and category filters

### DIFF
--- a/blog/index.html
+++ b/blog/index.html
@@ -4,20 +4,64 @@ title: Blog
 hide_language_switcher: true
 ---
 
-<div class="blog-list">
-    <h1 data-en="Latest Blog Posts" data-de="Neueste Blogbeiträge">Latest Blog Posts</h1>
+<div class="blog-list" data-blog-index>
+    <div class="blog-hero">
+      <p class="blog-kicker">Writing</p>
+      <h1 data-en="Latest Blog Posts" data-de="Neueste Blogbeiträge">Latest Blog Posts</h1>
+      <p class="blog-intro">Notes on side projects, agents, mobile development, health research, and the small systems that help me build.</p>
+    </div>
 
     <div class="blog-actions" aria-label="Blog subscription options">
       <a class="rss-link" href="{{ '/rss.xml' | relative_url }}" type="application/rss+xml">RSS feed</a>
     </div>
 
-    <ul>
+    <section class="blog-filter-panel" aria-label="Filter blog posts">
+      <label class="blog-search-label" for="blog-search">Search posts</label>
+      <div class="blog-search-wrap">
+        <input id="blog-search" class="blog-search-input" type="search" placeholder="Search titles, excerpts, or categories" autocomplete="off">
+      </div>
+
+      <div class="blog-category-filters" role="group" aria-label="Categories">
+        <button class="blog-category-filter is-active" type="button" data-blog-category="all">All</button>
+        {% assign sorted_categories = site.categories | sort %}
+        {% for category in sorted_categories %}
+          {% assign category_name = category[0] %}
+          <button class="blog-category-filter" type="button" data-blog-category="{{ category_name | slugify }}">{{ category_name | replace: '-', ' ' }}</button>
+        {% endfor %}
+      </div>
+
+      <p class="blog-results-summary" aria-live="polite">
+        Showing <span data-blog-visible-count>{{ site.posts | size }}</span> of {{ site.posts | size }} posts
+      </p>
+    </section>
+
+    <ul class="blog-posts" data-blog-posts>
       {% for post in site.posts %}
-        <li>
-          <h2><a href="{{ post.url | relative_url }}">{{ post.title }}</a></h2>
-          <p class="post-date">{{ post.date | date_to_string }}</p>
-          <div class="post-excerpt">{{ post.excerpt | strip_html | truncate: 180 }}</div>
+        {% capture searchable_categories %}{% for category in post.categories %} {{ category }} {{ category | replace: '-', ' ' }}{% endfor %}{% endcapture %}
+        <li class="blog-post-item" data-blog-post data-categories="{% for category in post.categories %}{{ category | slugify }}{% unless forloop.last %},{% endunless %}{% endfor %}" data-search="{{ post.title | append: ' ' | append: post.excerpt | append: searchable_categories | strip_html | normalize_whitespace | downcase | escape }}">
+          <article class="blog-post-card">
+            <div class="blog-post-card-meta">
+              <time class="post-date" datetime="{{ post.date | date_to_xmlschema }}">{{ post.date | date_to_string }}</time>
+              {% if post.categories %}
+                <span aria-hidden="true">•</span>
+                <div class="blog-post-categories" role="group" aria-label="Categories">
+                  {% for category in post.categories %}
+                    <button class="blog-post-category" type="button" data-blog-category-link="{{ category | slugify }}">{{ category | replace: '-', ' ' }}</button>
+                  {% endfor %}
+                </div>
+              {% endif %}
+            </div>
+            <h2><a href="{{ post.url | relative_url }}">{{ post.title }}</a></h2>
+            <div class="post-excerpt">{{ post.excerpt | strip_html | truncate: 180 }}</div>
+            <a href="{{ post.url | relative_url }}" class="read-more">Read more</a>
+          </article>
         </li>
       {% endfor %}
-    </ul> 
+    </ul>
+
+    <div class="blog-empty-state" data-blog-empty hidden>
+      <h2>No posts found</h2>
+      <p>Try a different search term or choose another category.</p>
+      <button class="blog-clear-filters" type="button" data-blog-clear>Clear filters</button>
+    </div>
 </div>

--- a/blog/index.html
+++ b/blog/index.html
@@ -5,7 +5,7 @@ hide_language_switcher: true
 ---
 
 <div class="blog-list" data-blog-index>
-    <h1>All Blog Posts</h1>
+    <h1 data-en="Latest Blog Posts" data-de="Neueste Blogbeiträge">Latest Blog Posts</h1>
 
     <div class="blog-actions" aria-label="Blog actions">
       <a class="rss-link" href="{{ '/rss.xml' | relative_url }}" type="application/rss+xml">RSS feed</a>
@@ -37,22 +37,18 @@ hide_language_switcher: true
       </p>
     </section>
 
-    <div class="blog-posts" data-blog-posts>
+    <ul data-blog-posts>
       {% for post in site.posts %}
         {% capture searchable_categories %}{% for category in post.categories %} {{ category }} {{ category | replace: '-', ' ' }}{% endfor %}{% endcapture %}
-        <article class="blog-post" data-blog-post data-categories="{% for category in post.categories %}{{ category | slugify }}{% unless forloop.last %},{% endunless %}{% endfor %}" data-search="{{ post.title | append: ' ' | append: post.excerpt | append: searchable_categories | strip_html | normalize_whitespace | downcase | escape }}">
-            <h2><a href="{{ post.url | relative_url }}">{{ post.title }}</a></h2>
-            <div class="blog-post-meta">
-                <time datetime="{{ post.date | date_to_xmlschema }}">{{ post.date | date: "%B %-d, %Y" }}</time>
-                {% if post.categories %}
-                    <span> | Categories: {{ post.categories | join: ", " }}</span>
-                {% endif %}
-            </div>
-            <p>{{ post.excerpt | strip_html | truncatewords: 50 }}</p>
-            <a href="{{ post.url | relative_url }}" class="read-more">Read more</a>
-        </article>
+        <li data-blog-post data-categories="{% for category in post.categories %}{{ category | slugify }}{% unless forloop.last %},{% endunless %}{% endfor %}" data-search="{{ post.title | append: ' ' | append: post.excerpt | append: searchable_categories | strip_html | normalize_whitespace | downcase | escape }}">
+          <h2><a href="{{ post.url | relative_url }}">{{ post.title }}</a></h2>
+          <p class="post-date">
+            <time datetime="{{ post.date | date_to_xmlschema }}">{{ post.date | date_to_string }}</time>
+          </p>
+          <div class="post-excerpt">{{ post.excerpt | strip_html | truncate: 180 }}</div>
+        </li>
       {% endfor %}
-    </div>
+    </ul>
 
     <div class="blog-empty-state" data-blog-empty hidden>
       <h2>No posts found</h2>

--- a/blog/index.html
+++ b/blog/index.html
@@ -5,17 +5,19 @@ hide_language_switcher: true
 ---
 
 <div class="blog-list" data-blog-index>
-    <div class="blog-hero">
-      <p class="blog-kicker">Writing</p>
-      <h1 data-en="Latest Blog Posts" data-de="Neueste Blogbeiträge">Latest Blog Posts</h1>
-      <p class="blog-intro">Notes on side projects, agents, mobile development, health research, and the small systems that help me build.</p>
-    </div>
+    <h1>All Blog Posts</h1>
 
-    <div class="blog-actions" aria-label="Blog subscription options">
+    <div class="blog-actions" aria-label="Blog actions">
       <a class="rss-link" href="{{ '/rss.xml' | relative_url }}" type="application/rss+xml">RSS feed</a>
+      <button class="blog-search-toggle" type="button" data-blog-filter-toggle aria-expanded="false" aria-controls="blog-filter-panel">
+        <svg class="blog-search-toggle-icon" aria-hidden="true" viewBox="0 0 24 24" fill="none">
+          <path d="m21 21-5.2-5.2m0 0a7.5 7.5 0 1 0-10.6-10.6 7.5 7.5 0 0 0 10.6 10.6Z" stroke="currentColor" stroke-width="2.25" stroke-linecap="round" stroke-linejoin="round"/>
+        </svg>
+        <span class="visually-hidden">Search and filter posts</span>
+      </button>
     </div>
 
-    <section class="blog-filter-panel" aria-label="Filter blog posts">
+    <section id="blog-filter-panel" class="blog-filter-panel" aria-label="Filter blog posts" hidden>
       <label class="blog-search-label" for="blog-search">Search posts</label>
       <div class="blog-search-wrap">
         <input id="blog-search" class="blog-search-input" type="search" placeholder="Search titles, excerpts, or categories" autocomplete="off">
@@ -35,29 +37,22 @@ hide_language_switcher: true
       </p>
     </section>
 
-    <ul class="blog-posts" data-blog-posts>
+    <div class="blog-posts" data-blog-posts>
       {% for post in site.posts %}
         {% capture searchable_categories %}{% for category in post.categories %} {{ category }} {{ category | replace: '-', ' ' }}{% endfor %}{% endcapture %}
-        <li class="blog-post-item" data-blog-post data-categories="{% for category in post.categories %}{{ category | slugify }}{% unless forloop.last %},{% endunless %}{% endfor %}" data-search="{{ post.title | append: ' ' | append: post.excerpt | append: searchable_categories | strip_html | normalize_whitespace | downcase | escape }}">
-          <article class="blog-post-card">
-            <div class="blog-post-card-meta">
-              <time class="post-date" datetime="{{ post.date | date_to_xmlschema }}">{{ post.date | date_to_string }}</time>
-              {% if post.categories %}
-                <span aria-hidden="true">•</span>
-                <div class="blog-post-categories" role="group" aria-label="Categories">
-                  {% for category in post.categories %}
-                    <button class="blog-post-category" type="button" data-blog-category-link="{{ category | slugify }}">{{ category | replace: '-', ' ' }}</button>
-                  {% endfor %}
-                </div>
-              {% endif %}
-            </div>
+        <article class="blog-post" data-blog-post data-categories="{% for category in post.categories %}{{ category | slugify }}{% unless forloop.last %},{% endunless %}{% endfor %}" data-search="{{ post.title | append: ' ' | append: post.excerpt | append: searchable_categories | strip_html | normalize_whitespace | downcase | escape }}">
             <h2><a href="{{ post.url | relative_url }}">{{ post.title }}</a></h2>
-            <div class="post-excerpt">{{ post.excerpt | strip_html | truncate: 180 }}</div>
+            <div class="blog-post-meta">
+                <time datetime="{{ post.date | date_to_xmlschema }}">{{ post.date | date: "%B %-d, %Y" }}</time>
+                {% if post.categories %}
+                    <span> | Categories: {{ post.categories | join: ", " }}</span>
+                {% endif %}
+            </div>
+            <p>{{ post.excerpt | strip_html | truncatewords: 50 }}</p>
             <a href="{{ post.url | relative_url }}" class="read-more">Read more</a>
-          </article>
-        </li>
+        </article>
       {% endfor %}
-    </ul>
+    </div>
 
     <div class="blog-empty-state" data-blog-empty hidden>
       <h2>No posts found</h2>

--- a/script.js
+++ b/script.js
@@ -187,10 +187,25 @@ function initBlogFilters() {
     const visibleCount = blogIndex.querySelector('[data-blog-visible-count]');
     const emptyState = blogIndex.querySelector('[data-blog-empty]');
     const clearButton = blogIndex.querySelector('[data-blog-clear]');
+    const filterPanel = blogIndex.querySelector('.blog-filter-panel');
+    const filterToggle = blogIndex.querySelector('[data-blog-filter-toggle]');
 
     const params = new URLSearchParams(window.location.search);
     let selectedCategory = params.get('category') || 'all';
     let searchTerm = params.get('q') || '';
+
+    function setFilterPanelOpen(open, shouldFocus = false) {
+        if (!filterPanel) return;
+
+        filterPanel.hidden = !open;
+        if (filterToggle) {
+            filterToggle.setAttribute('aria-expanded', open ? 'true' : 'false');
+        }
+
+        if (open && shouldFocus) {
+            searchInput?.focus();
+        }
+    }
 
     function setActiveCategory(category) {
         selectedCategory = category || 'all';
@@ -259,7 +274,8 @@ function initBlogFilters() {
         button.addEventListener('click', () => {
             setActiveCategory(button.dataset.blogCategoryLink);
             filterPosts();
-            blogIndex.querySelector('.blog-filter-panel')?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+            setFilterPanelOpen(true);
+            filterPanel?.scrollIntoView({ behavior: 'smooth', block: 'start' });
         });
     });
 
@@ -273,8 +289,22 @@ function initBlogFilters() {
         });
     }
 
+    if (filterToggle && filterPanel) {
+        filterToggle.addEventListener('click', () => {
+            setFilterPanelOpen(filterPanel.hidden, true);
+        });
+
+        filterPanel.addEventListener('keydown', event => {
+            if (event.key === 'Escape') {
+                setFilterPanelOpen(false);
+                filterToggle.focus();
+            }
+        });
+    }
+
     const hasCategory = categoryButtons.some(button => button.dataset.blogCategory === selectedCategory);
     setActiveCategory(hasCategory ? selectedCategory : 'all');
+    setFilterPanelOpen(Boolean(searchTerm || selectedCategory !== 'all'));
     filterPosts();
 }
 

--- a/script.js
+++ b/script.js
@@ -86,6 +86,9 @@ document.addEventListener('DOMContentLoaded', () => {
     // Initialize AI mode
     initAiMode();
 
+    // Initialize blog search and category filters when present
+    initBlogFilters();
+
     // Add theme toggle event listener if the button exists
     const themeToggle = document.getElementById('theme-toggle');
     if (themeToggle) {
@@ -172,6 +175,108 @@ document.addEventListener('DOMContentLoaded', () => {
         setLanguage(savedLanguage);
     }
 });
+
+function initBlogFilters() {
+    const blogIndex = document.querySelector('[data-blog-index]');
+    if (!blogIndex) return;
+
+    const searchInput = blogIndex.querySelector('#blog-search');
+    const categoryButtons = Array.from(blogIndex.querySelectorAll('[data-blog-category]'));
+    const categoryLinks = Array.from(blogIndex.querySelectorAll('[data-blog-category-link]'));
+    const posts = Array.from(blogIndex.querySelectorAll('[data-blog-post]'));
+    const visibleCount = blogIndex.querySelector('[data-blog-visible-count]');
+    const emptyState = blogIndex.querySelector('[data-blog-empty]');
+    const clearButton = blogIndex.querySelector('[data-blog-clear]');
+
+    const params = new URLSearchParams(window.location.search);
+    let selectedCategory = params.get('category') || 'all';
+    let searchTerm = params.get('q') || '';
+
+    function setActiveCategory(category) {
+        selectedCategory = category || 'all';
+        categoryButtons.forEach(button => {
+            const isActive = button.dataset.blogCategory === selectedCategory;
+            button.classList.toggle('is-active', isActive);
+            button.setAttribute('aria-pressed', isActive ? 'true' : 'false');
+        });
+    }
+
+    function updateUrl() {
+        const nextParams = new URLSearchParams(window.location.search);
+
+        if (searchTerm) {
+            nextParams.set('q', searchTerm);
+        } else {
+            nextParams.delete('q');
+        }
+
+        if (selectedCategory && selectedCategory !== 'all') {
+            nextParams.set('category', selectedCategory);
+        } else {
+            nextParams.delete('category');
+        }
+
+        const query = nextParams.toString();
+        const nextUrl = `${window.location.pathname}${query ? `?${query}` : ''}${window.location.hash}`;
+        window.history.replaceState({}, '', nextUrl);
+    }
+
+    function filterPosts() {
+        const normalizedSearch = searchTerm.trim().toLowerCase();
+        let shown = 0;
+
+        posts.forEach(post => {
+            const postCategories = (post.dataset.categories || '').split(',').filter(Boolean);
+            const categoryMatches = selectedCategory === 'all' || postCategories.includes(selectedCategory);
+            const searchMatches = !normalizedSearch || (post.dataset.search || '').includes(normalizedSearch);
+            const shouldShow = categoryMatches && searchMatches;
+
+            post.hidden = !shouldShow;
+            if (shouldShow) shown += 1;
+        });
+
+        if (visibleCount) visibleCount.textContent = shown.toString();
+        if (emptyState) emptyState.hidden = shown !== 0;
+        updateUrl();
+    }
+
+    if (searchInput) {
+        searchInput.value = searchTerm;
+        searchInput.addEventListener('input', () => {
+            searchTerm = searchInput.value;
+            filterPosts();
+        });
+    }
+
+    categoryButtons.forEach(button => {
+        button.addEventListener('click', () => {
+            setActiveCategory(button.dataset.blogCategory);
+            filterPosts();
+        });
+    });
+
+    categoryLinks.forEach(button => {
+        button.addEventListener('click', () => {
+            setActiveCategory(button.dataset.blogCategoryLink);
+            filterPosts();
+            blogIndex.querySelector('.blog-filter-panel')?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+        });
+    });
+
+    if (clearButton) {
+        clearButton.addEventListener('click', () => {
+            searchTerm = '';
+            if (searchInput) searchInput.value = '';
+            setActiveCategory('all');
+            filterPosts();
+            searchInput?.focus();
+        });
+    }
+
+    const hasCategory = categoryButtons.some(button => button.dataset.blogCategory === selectedCategory);
+    setActiveCategory(hasCategory ? selectedCategory : 'all');
+    filterPosts();
+}
 
 // Language switching functionality
 function setLanguage(lang) {

--- a/styles.css
+++ b/styles.css
@@ -706,7 +706,6 @@ body.ai-mode .ai-mode-panel {
 
 /* Blog Styles */
 .blog-post,
-.blog-post-card,
 .blog-filter-panel,
 .blog-empty-state {
     background: var(--section-bg);
@@ -723,10 +722,9 @@ body.ai-mode .ai-mode-panel {
     transition: all 0.4s cubic-bezier(0.4, 0, 0.2, 1);
 }
 
-.blog-post h2,
-.blog-post-card h2 {
+.blog-post h2 {
     font-size: 2rem;
-    margin-bottom: 1rem;
+    margin-bottom: 1.5rem;
 }
 
 [data-theme="dark"] .blog-post h2,
@@ -734,8 +732,7 @@ body.ai-mode .ai-mode-panel {
     color: var(--accent-color);
 }
 
-.blog-post-meta,
-.blog-post-card-meta {
+.blog-post-meta {
     font-size: 0.9rem;
     color: var(--secondary-color);
     margin-bottom: 1.5rem;
@@ -746,67 +743,49 @@ body.ai-mode .ai-mode-panel {
     margin-bottom: 2rem;
 }
 
-.blog-post a,
-.blog-post-card a {
+.blog-post a {
     color: var(--accent-color);
     text-decoration: none;
     transition: all 0.3s ease;
 }
 
-.blog-post a:hover,
-.blog-post-card a:hover {
+.blog-post a:hover {
     text-decoration: underline;
 }
 
 .blog-list {
-    max-width: 860px;
-    margin: 80px auto 0;
+    max-width: 800px;
+    margin: 0 auto;
     padding: 120px 20px 40px;
-}
-
-.blog-hero {
-    text-align: center;
-    margin-bottom: 1.5rem;
-}
-
-.blog-kicker {
-    color: var(--accent-color);
-    font-size: 0.85rem;
-    font-weight: 700;
-    letter-spacing: 0.12em;
-    margin-bottom: 0.5rem;
-    text-transform: uppercase;
+    margin-top: 80px;
 }
 
 .blog-list h1 {
     color: var(--primary-color);
-    margin-bottom: 1rem;
+    margin-bottom: 2.5rem;
     text-align: center;
-}
-
-.blog-intro {
-    max-width: 640px;
-    margin: 0 auto;
-    color: var(--text-color);
-    opacity: 0.82;
 }
 
 .blog-actions {
     display: flex;
+    gap: 0.6rem;
     justify-content: center;
-    margin-bottom: 1.5rem;
+    margin: -1rem 0 2rem;
 }
 
 .rss-link,
+.blog-search-toggle,
 .blog-clear-filters,
-.blog-category-filter,
-.blog-post-category {
+.blog-category-filter {
+    align-items: center;
     color: var(--accent-color);
     border: 1px solid var(--glass-border);
     background: var(--hover-bg);
     border-radius: 999px;
     cursor: pointer;
+    display: inline-flex;
     font: inherit;
+    justify-content: center;
     text-decoration: none;
     transition: all 0.3s ease;
 }
@@ -816,19 +795,45 @@ body.ai-mode .ai-mode-panel {
     padding: 0.55rem 0.9rem;
 }
 
+.blog-search-toggle {
+    width: 2.55rem;
+    height: 2.55rem;
+    padding: 0;
+}
+
+.blog-search-toggle-icon {
+    display: block;
+    width: 1.1rem;
+    height: 1.1rem;
+    flex: 0 0 auto;
+}
+
 .rss-link:hover,
+.blog-search-toggle:hover,
+.blog-search-toggle[aria-expanded="true"],
 .blog-clear-filters:hover,
 .blog-category-filter:hover,
-.blog-category-filter.is-active,
-.blog-post-category:hover {
+.blog-category-filter.is-active {
     background: var(--accent-color);
     color: var(--on-accent-color);
     transform: translateY(-1px);
 }
 
+.blog-search-toggle:focus-visible,
+.blog-search-input:focus-visible,
+.blog-category-filter:focus-visible,
+.blog-clear-filters:focus-visible {
+    outline: 3px solid var(--hover-bg);
+    outline-offset: 3px;
+}
+
 .blog-filter-panel {
     padding: 1.25rem;
     margin-bottom: 2rem;
+}
+
+.blog-filter-panel[hidden] {
+    display: none;
 }
 
 .blog-search-label {
@@ -860,8 +865,7 @@ body.ai-mode .ai-mode-panel {
     background: rgba(44, 54, 57, 0.55);
 }
 
-.blog-category-filters,
-.blog-post-categories {
+.blog-category-filters {
     display: flex;
     flex-wrap: wrap;
     gap: 0.5rem;
@@ -871,14 +875,9 @@ body.ai-mode .ai-mode-panel {
     margin-top: 1rem;
 }
 
-.blog-category-filter,
-.blog-post-category {
+.blog-category-filter {
     padding: 0.4rem 0.75rem;
     text-transform: capitalize;
-}
-
-.blog-post-category {
-    font-size: 0.85rem;
 }
 
 .blog-results-summary {
@@ -888,38 +887,12 @@ body.ai-mode .ai-mode-panel {
 }
 
 .blog-posts {
-    display: grid;
-    gap: 1.5rem;
-    list-style: none;
     margin: 0;
-    padding: 0;
 }
 
-.blog-post-item[hidden],
+.blog-post[hidden],
 .blog-empty-state[hidden] {
     display: none;
-}
-
-.blog-post-card {
-    padding: 1.5rem;
-    transition: all 0.3s ease;
-}
-
-.blog-post-card:hover {
-    transform: translateY(-3px);
-    border-color: var(--accent-color);
-    box-shadow: 0 8px 25px rgba(169, 132, 103, 0.15);
-}
-
-.blog-post-card-meta {
-    display: flex;
-    flex-wrap: wrap;
-    align-items: center;
-    gap: 0.5rem;
-}
-
-.post-excerpt {
-    margin-bottom: 1.25rem;
 }
 
 .read-more {
@@ -960,9 +933,8 @@ body.ai-mode .ai-mode-panel {
 /* Responsive adjustments */
 @media (max-width: 768px) {
     .blog-post,
-    .blog-post-card,
     .blog-filter-panel {
-        padding: 1.25rem;
+        padding: 1.5rem;
     }
 
     .blog-post {
@@ -972,16 +944,6 @@ body.ai-mode .ai-mode-panel {
     .blog-list {
         padding: 1rem;
         margin-top: 80px;
-    }
-
-    .blog-post h2,
-    .blog-post-card h2 {
-        font-size: 1.45rem;
-    }
-
-    .blog-post-card-meta {
-        align-items: flex-start;
-        flex-direction: column;
     }
 }
 
@@ -1381,11 +1343,12 @@ body::before {
     margin: 12px 0 0;
 }
 
-.rss-link {
+.rss-link,
+.blog-search-toggle {
     display: inline-flex;
     align-items: center;
+    justify-content: center;
     min-height: 38px;
-    padding: 0 16px;
     border: 1px solid currentColor;
     background: var(--warm-cream);
     color: var(--warm-page-ink);
@@ -1397,10 +1360,28 @@ body::before {
     font-weight: 850;
 }
 
-.rss-link:hover {
+.rss-link {
+    padding: 0 16px;
+}
+
+.blog-search-toggle {
+    width: 38px;
+    height: 38px;
+    padding: 0;
+}
+
+.rss-link:hover,
+.blog-search-toggle:hover,
+.blog-search-toggle[aria-expanded="true"] {
     background: var(--warm-amber);
+    color: var(--warm-page-ink);
     text-decoration: underline;
     text-underline-offset: 3px;
+}
+
+.blog-search-toggle:hover,
+.blog-search-toggle[aria-expanded="true"] {
+    text-decoration: none;
 }
 
 .blog-list ul {

--- a/styles.css
+++ b/styles.css
@@ -10,6 +10,7 @@
     --glass-border: rgba(255, 255, 255, 0.4);
     --hover-bg: rgba(169, 132, 103, 0.1);
     --accent-color: #9C6644;
+    --on-accent-color: #FFF8EF;
 }
 
 [data-theme="dark"] {
@@ -24,6 +25,7 @@
     --glass-border: rgba(169, 132, 103, 0.2);
     --hover-bg: rgba(169, 132, 103, 0.15);
     --accent-color: #CB997E;
+    --on-accent-color: #2C3639;
 }
 
 * {
@@ -703,21 +705,28 @@ body.ai-mode .ai-mode-panel {
 }
 
 /* Blog Styles */
-.blog-post {
+.blog-post,
+.blog-post-card,
+.blog-filter-panel,
+.blog-empty-state {
     background: var(--section-bg);
     border-radius: 1rem;
-    padding: 2rem;
-    margin-bottom: 3rem;
     box-shadow: 0 4px 20px var(--card-shadow);
-    transition: all 0.4s cubic-bezier(0.4, 0, 0.2, 1);
     border: 1px solid var(--glass-border);
     backdrop-filter: blur(10px);
     -webkit-backdrop-filter: blur(10px);
 }
 
-.blog-post h2 {
+.blog-post {
+    padding: 2rem;
+    margin-bottom: 3rem;
+    transition: all 0.4s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.blog-post h2,
+.blog-post-card h2 {
     font-size: 2rem;
-    margin-bottom: 1.5rem;
+    margin-bottom: 1rem;
 }
 
 [data-theme="dark"] .blog-post h2,
@@ -725,7 +734,8 @@ body.ai-mode .ai-mode-panel {
     color: var(--accent-color);
 }
 
-.blog-post-meta {
+.blog-post-meta,
+.blog-post-card-meta {
     font-size: 0.9rem;
     color: var(--secondary-color);
     margin-bottom: 1.5rem;
@@ -736,27 +746,199 @@ body.ai-mode .ai-mode-panel {
     margin-bottom: 2rem;
 }
 
-.blog-post a {
+.blog-post a,
+.blog-post-card a {
     color: var(--accent-color);
     text-decoration: none;
     transition: all 0.3s ease;
 }
 
-.blog-post a:hover {
+.blog-post a:hover,
+.blog-post-card a:hover {
     text-decoration: underline;
 }
 
 .blog-list {
-    max-width: 800px;
-    margin: 0 auto;
+    max-width: 860px;
+    margin: 80px auto 0;
     padding: 120px 20px 40px;
-    margin-top: 80px;
+}
+
+.blog-hero {
+    text-align: center;
+    margin-bottom: 1.5rem;
+}
+
+.blog-kicker {
+    color: var(--accent-color);
+    font-size: 0.85rem;
+    font-weight: 700;
+    letter-spacing: 0.12em;
+    margin-bottom: 0.5rem;
+    text-transform: uppercase;
 }
 
 .blog-list h1 {
     color: var(--primary-color);
-    margin-bottom: 2.5rem;
+    margin-bottom: 1rem;
     text-align: center;
+}
+
+.blog-intro {
+    max-width: 640px;
+    margin: 0 auto;
+    color: var(--text-color);
+    opacity: 0.82;
+}
+
+.blog-actions {
+    display: flex;
+    justify-content: center;
+    margin-bottom: 1.5rem;
+}
+
+.rss-link,
+.blog-clear-filters,
+.blog-category-filter,
+.blog-post-category {
+    color: var(--accent-color);
+    border: 1px solid var(--glass-border);
+    background: var(--hover-bg);
+    border-radius: 999px;
+    cursor: pointer;
+    font: inherit;
+    text-decoration: none;
+    transition: all 0.3s ease;
+}
+
+.rss-link,
+.blog-clear-filters {
+    padding: 0.55rem 0.9rem;
+}
+
+.rss-link:hover,
+.blog-clear-filters:hover,
+.blog-category-filter:hover,
+.blog-category-filter.is-active,
+.blog-post-category:hover {
+    background: var(--accent-color);
+    color: var(--on-accent-color);
+    transform: translateY(-1px);
+}
+
+.blog-filter-panel {
+    padding: 1.25rem;
+    margin-bottom: 2rem;
+}
+
+.blog-search-label {
+    display: block;
+    color: var(--primary-color);
+    font-weight: 650;
+    margin-bottom: 0.5rem;
+}
+
+.blog-search-input {
+    width: 100%;
+    border: 1px solid var(--glass-border);
+    border-radius: 999px;
+    background: rgba(255, 255, 255, 0.55);
+    color: var(--text-color);
+    font: inherit;
+    outline: none;
+    padding: 0.85rem 1rem;
+    transition: border-color 0.3s ease, box-shadow 0.3s ease, background 0.3s ease;
+}
+
+.blog-search-input:focus {
+    border-color: var(--accent-color);
+    box-shadow: 0 0 0 3px var(--hover-bg);
+    background: var(--section-bg);
+}
+
+[data-theme="dark"] .blog-search-input {
+    background: rgba(44, 54, 57, 0.55);
+}
+
+.blog-category-filters,
+.blog-post-categories {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+}
+
+.blog-category-filters {
+    margin-top: 1rem;
+}
+
+.blog-category-filter,
+.blog-post-category {
+    padding: 0.4rem 0.75rem;
+    text-transform: capitalize;
+}
+
+.blog-post-category {
+    font-size: 0.85rem;
+}
+
+.blog-results-summary {
+    color: var(--secondary-color);
+    font-size: 0.95rem;
+    margin-top: 1rem;
+}
+
+.blog-posts {
+    display: grid;
+    gap: 1.5rem;
+    list-style: none;
+    margin: 0;
+    padding: 0;
+}
+
+.blog-post-item[hidden],
+.blog-empty-state[hidden] {
+    display: none;
+}
+
+.blog-post-card {
+    padding: 1.5rem;
+    transition: all 0.3s ease;
+}
+
+.blog-post-card:hover {
+    transform: translateY(-3px);
+    border-color: var(--accent-color);
+    box-shadow: 0 8px 25px rgba(169, 132, 103, 0.15);
+}
+
+.blog-post-card-meta {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+.post-excerpt {
+    margin-bottom: 1.25rem;
+}
+
+.read-more {
+    font-weight: 650;
+}
+
+.blog-empty-state {
+    margin-top: 1.5rem;
+    padding: 2rem;
+    text-align: center;
+}
+
+.blog-empty-state h2 {
+    color: var(--primary-color);
+    margin-bottom: 0.5rem;
+}
+
+.blog-empty-state p {
+    margin-bottom: 1rem;
 }
 
 /* Individual Blog Post Title in List */
@@ -777,14 +959,29 @@ body.ai-mode .ai-mode-panel {
 
 /* Responsive adjustments */
 @media (max-width: 768px) {
+    .blog-post,
+    .blog-post-card,
+    .blog-filter-panel {
+        padding: 1.25rem;
+    }
+
     .blog-post {
-        padding: 1.5rem;
         margin-bottom: 3rem;
     }
 
     .blog-list {
         padding: 1rem;
         margin-top: 80px;
+    }
+
+    .blog-post h2,
+    .blog-post-card h2 {
+        font-size: 1.45rem;
+    }
+
+    .blog-post-card-meta {
+        align-items: flex-start;
+        flex-direction: column;
     }
 }
 

--- a/styles.css
+++ b/styles.css
@@ -891,6 +891,7 @@ body.ai-mode .ai-mode-panel {
 }
 
 .blog-post[hidden],
+.blog-list [data-blog-post][hidden],
 .blog-empty-state[hidden] {
     display: none;
 }
@@ -1382,6 +1383,110 @@ body::before {
 .blog-search-toggle:hover,
 .blog-search-toggle[aria-expanded="true"] {
     text-decoration: none;
+}
+
+.blog-filter-panel {
+    margin: 12px 0 0;
+    padding: 18px;
+    border: 1px solid currentColor;
+    border-radius: 0;
+    background: var(--warm-cream);
+    color: var(--warm-page-ink);
+    box-shadow: none;
+    backdrop-filter: none;
+    -webkit-backdrop-filter: none;
+}
+
+.blog-filter-panel[hidden] {
+    display: none;
+}
+
+.blog-search-label,
+.blog-results-summary {
+    color: inherit;
+    font-size: 12px;
+    line-height: 1.2;
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    font-weight: 850;
+}
+
+.blog-search-input {
+    width: 100%;
+    margin: 0;
+    border: 1px solid currentColor;
+    border-radius: 0;
+    background: var(--warm-hero);
+    color: var(--warm-page-ink);
+    font: inherit;
+    padding: 12px 14px;
+    letter-spacing: -0.02em;
+}
+
+.blog-search-input:focus {
+    border-color: currentColor;
+    box-shadow: 0 0 0 4px var(--warm-focus);
+    background: var(--warm-hero);
+}
+
+.blog-category-filters {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    margin-top: 14px;
+}
+
+.blog-category-filter,
+.blog-clear-filters {
+    min-height: 34px;
+    padding: 0 12px;
+    border: 1px solid currentColor;
+    border-radius: 0;
+    background: var(--warm-hero);
+    color: var(--warm-page-ink);
+    font-size: 12px;
+    line-height: 1;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    font-weight: 850;
+}
+
+.blog-category-filter:hover,
+.blog-category-filter.is-active,
+.blog-clear-filters:hover {
+    background: var(--warm-amber);
+    color: var(--warm-page-ink);
+    transform: translateY(-1px);
+}
+
+.blog-results-summary {
+    margin: 14px 0 0;
+}
+
+.blog-empty-state {
+    margin-top: 12px;
+    padding: 24px;
+    border: 1px solid currentColor;
+    border-radius: 0;
+    background: var(--warm-cream);
+    color: var(--warm-page-ink);
+    box-shadow: none;
+    text-align: left;
+    backdrop-filter: none;
+    -webkit-backdrop-filter: none;
+}
+
+.blog-empty-state h2 {
+    margin: 0 0 8px;
+    color: inherit;
+    font-size: clamp(24px, 3vw, 34px);
+    line-height: 1.02;
+    letter-spacing: -0.045em;
+    font-weight: 860;
+}
+
+.blog-empty-state p {
+    margin: 0 0 16px;
 }
 
 .blog-list ul {


### PR DESCRIPTION
## Summary
- add a search field to the blog index that filters rendered posts by title, excerpt, and category text
- add category filter chips generated from existing Jekyll categories, plus per-post category chips
- keep filters shareable with `q` / `category` URL params while preserving unrelated params and hash fragments
- restyle the blog list cards and filter controls to match the existing earthy glass-card visual style

## Verification
- `bundle exec jekyll build`
- static generated HTML checks for post/category/search attributes
- browser smoke test on local Jekyll server:
  - search `side project` shows the three side-project posts
  - combining `q=side project` with `category=health` shows the empty state
  - existing `utm_source` query param and `#filters` hash are preserved
- active button contrast checked in light and dark themes
